### PR TITLE
feat: adiciona Makefile para auxiliar na manipulação do repositório

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ run_docker:
 # `make stop_docker`: stops the server using docker-compose
 .PHONY: stop_docker
 stop_docker:
+	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml stop
+
+# `make clean_docker`: removes the server using docker-compose
+.PHONY: clean_docker
+clean_docker:
 	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml down
 
 # `make shell_docker`: runs a shell in the server using docker-compose

--- a/Makefile
+++ b/Makefile
@@ -37,15 +37,30 @@ lint:
 migrations:
 	$(PYTHON) manage.py makemigrations
 
+# `make migrations_docker`: checks for model changes and generates migrations using docker-compose
+.PHONY: migrations_docker
+migrations_docker:
+	docker-compose exec api python manage.py makemigrations
+
 # `make migrate`: applies migrations
 .PHONY: migrate
 migrate:
 	$(PYTHON) manage.py migrate
 
+# `make migrate_docker`: applies migrations using docker-compose
+.PHONY: migrate_docker
+migrate_docker:
+	docker-compose exec api python manage.py migrate
+
 # `make superuser`: creates a superuser
 .PHONY: superuser
 superuser:
 	$(PYTHON) manage.py createsuperuser
+
+# `make superuser_docker`: creates a superuser using docker-compose
+.PHONY: superuser_docker
+superuser_docker:
+	docker-compose exec api python manage.py createsuperuser
 
 # `make run_local`: runs the server using manage.py
 .PHONY: run_local
@@ -62,29 +77,29 @@ run_local:
 # `make run_docker`: runs the server using docker-compose
 .PHONY: run_docker
 run_docker:
-	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml up --build --detach
+	docker-compose up --build --force-recreate --detach
 
 # `make stop_docker`: stops the server using docker-compose
 .PHONY: stop_docker
 stop_docker:
-	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml stop
+	docker-compose stop
 
 # `make clean_docker`: removes the server using docker-compose and delete all volumes
 .PHONY: clean_docker
 clean_docker:
-	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml down --volumes
+	docker-compose down --volumes
 
 # `make shell_docker`: runs a shell in the server using docker-compose
 .PHONY: shell_docker
 shell_docker:
-	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml exec api bash
+	docker-compose exec api bash
 
 # `make logs_docker`: shows the logs of the server using docker-compose
 .PHONY: logs_docker
 logs_docker:
-	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml logs --tail=500 -f
+	docker-compose logs --tail=500 -f
 
 # `make status_docker`: shows the status of the server using docker-compose
 .PHONY: status_docker
 status_docker:
-	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml ps
+	docker-compose ps

--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,10 @@ run_docker:
 stop_docker:
 	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml stop
 
-# `make clean_docker`: removes the server using docker-compose
+# `make clean_docker`: removes the server using docker-compose and delete all volumes
 .PHONY: clean_docker
 clean_docker:
-	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml down
+	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml down --volumes
 
 # `make shell_docker`: runs a shell in the server using docker-compose
 .PHONY: shell_docker

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,85 @@
+# Get the executables we're using
+POETRY=$(shell which poetry)
+PYTHON=$(shell poetry run which python)
+
+# `make install`: installs dependencies
+.PHONY: install
+install:
+	$(POETRY) install
+
+# `make add`: adds a new dependency
+ifeq (add,$(firstword $(MAKECMDGOALS)))
+	ADD_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+	$(eval $(ADD_ARGS):;@:)
+endif
+
+.PHONY: add
+add:
+	$(POETRY) add $(ADD_ARGS)
+
+# `make remove`: removes a dependency
+ifeq (remove,$(firstword $(MAKECMDGOALS)))
+	REMOVE_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+	$(eval $(REMOVE_ARGS):;@:)
+endif
+
+.PHONY: remove
+remove:
+	$(POETRY) remove $(REMOVE_ARGS)
+
+# `make lint`: runs linters
+.PHONY: lint
+lint:
+	$(POETRY) run lint
+
+# `make migrations`: checks for model changes and generates migrations
+.PHONY: migrations
+migrations:
+	$(PYTHON) manage.py makemigrations
+
+# `make migrate`: applies migrations
+.PHONY: migrate
+migrate:
+	$(PYTHON) manage.py migrate
+
+# `make superuser`: creates a superuser
+.PHONY: superuser
+superuser:
+	$(PYTHON) manage.py createsuperuser
+
+# `make run_local`: runs the server using manage.py
+.PHONY: run_local
+run_local:
+	@echo "Touching the log file to ensure it exists..."
+	@touch basedosdados_api/django.log
+	@echo "Checking for model changes..."
+	@make migrations
+	@echo "Applying migrations..."
+	@make migrate
+	@echo "Running the server at http://0.0.0.0:8080/..."
+	$(PYTHON) manage.py runserver 0.0.0.0:8080
+
+# `make run_docker`: runs the server using docker-compose
+.PHONY: run_docker
+run_docker:
+	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml up --build --detach
+
+# `make stop_docker`: stops the server using docker-compose
+.PHONY: stop_docker
+stop_docker:
+	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml down
+
+# `make shell_docker`: runs a shell in the server using docker-compose
+.PHONY: shell_docker
+shell_docker:
+	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml exec api bash
+
+# `make logs_docker`: shows the logs of the server using docker-compose
+.PHONY: logs_docker
+logs_docker:
+	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml logs --tail=500 -f
+
+# `make status_docker`: shows the status of the server using docker-compose
+.PHONY: status_docker
+status_docker:
+	@docker compose -f docker-compose.yaml -f docker-compose.dev.yaml ps

--- a/basedosdados_api/settings/base.py
+++ b/basedosdados_api/settings/base.py
@@ -157,7 +157,7 @@ LOGGING = {
         # Log to a text file that can be rotated by logrotate
         "logfile": {
             "class": "logging.handlers.WatchedFileHandler",
-            "filename": "/var/log/django/basedosdados_api.log",
+            "filename": str(BASE_DIR / "django.log"),
         },
     },
     "loggers": {

--- a/basedosdados_api/settings/prod.py
+++ b/basedosdados_api/settings/prod.py
@@ -44,3 +44,8 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = nonull_getenv("EMAIL_HOST_USER")
 SERVER_EMAIL = nonull_getenv("EMAIL_HOST_USER")
+
+# Set logging path for production
+LOGGING["handlers"]["logfile"][  # noqa
+    "filename"
+] = "/var/log/django/basedosdados_api.log"


### PR DESCRIPTION
### To-do

- [x] Adaptar comandos após #13 

### Modificações

- Troca do caminho padrão do arquivo de log para `BASE_DIR / "django.log"` (permite a execução sem privilégios de superuser)
- Adiciona arquivo `Makefile` (comandos disponíveis descritos abaixo)

### Como usar o Makefile

#### Requisitos:

- Básico: [GNU Make](https://www.gnu.org/software/make/)
- Básico: [poetry](https://python-poetry.org/)
- Para executar com Docker: [Docker](https://www.docker.com/)
- Para executar com Docker: [Compose plugin](https://docs.docker.com/compose/install/linux/)
- Opcional, mas recomendado: [virtualenv](https://virtualenv.pypa.io/en/latest/), [miniconda](https://docs.conda.io/en/latest/miniconda.html) ou similares

**Observação**: caso deseje usar um ambiente virtual (recomendado), ele deve estar ativado antes da execução dos comandos.

#### Comandos disponíveis:

- `make install`: instala dependências do repositório
- `make add <pacote>`: adiciona um pacote Python às dependências
- `make remove <pacote>`: remove um pacote Python às dependências
- `make lint`: executa o script de lint
- `make migrations`: verifica modificações nos modelos de dados e gera as migrações
- `make migrate`: aplica as migrações geradas (é incremental, se não existem novas migrações nada é realizado)
- `make superuser`: inicia o procedimento de criação de superusuário do Django (esse superusuário só serve para a execução local)
- `make run_local`: inicia a API em execução local
- `make run_docker`: inicia a API em containers com Docker Compose
- `make stop_docker`: interrompe os containers da API
- `make clean_docker`: remove os containers da API e limpa os dados
- `make shell_docker`: abre um shell dentro do container da API (pode, por exemplo, ser usado para criar um superusuário para a API do container)
- `make logs_docker`: exibe e acompanha os logs para os containers da API
- `make status_docker`: exibe o status dos containers da API