### PR TITLE
Fixes

### DIFF
--- a/basedosdados_api/api/v1/models.py
+++ b/basedosdados_api/api/v1/models.py
@@ -18,14 +18,13 @@ from basedosdados_api.api.v1.validators import (
 
 class Area(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
-    name = models.CharField(max_length=255, blank=False, null=False)
-    slug = models.SlugField(unique=True)
     key = models.CharField(
         max_length=255,
         null=True,
         blank=False,
         validators=[validate_area_key, validate_is_valid_area_key],
     )
+    name = models.CharField(max_length=255, blank=False, null=False)
 
     def __str__(self):
         return str(self.slug)
@@ -240,6 +239,7 @@ class Organization(models.Model):
     facebook = models.URLField(blank=True, null=True)
     linkedin = models.URLField(blank=True, null=True)
     instagram = models.URLField(blank=True, null=True)
+    image = models.ImageField()
 
     def __str__(self):
         return str(self.slug)
@@ -567,6 +567,7 @@ class Entity(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
     slug = models.SlugField(unique=True)
     name = models.CharField(max_length=255)
+    category = models.CharField(max_length=255)
 
     def __str__(self):
         return str(self.slug)

--- a/basedosdados_api/api/v1/models.py
+++ b/basedosdados_api/api/v1/models.py
@@ -350,7 +350,7 @@ class Table(models.Model):
 
 class BigQueryTypes(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
-    slug = models.SlugField(unique=False)
+    name = models.CharField(max_length=255)
 
     def __str__(self):
         return str(self.name)

--- a/basedosdados_api/api/v1/models.py
+++ b/basedosdados_api/api/v1/models.py
@@ -298,6 +298,13 @@ class Table(models.Model):
     dataset = models.ForeignKey(
         "Dataset", on_delete=models.CASCADE, related_name="tables"
     )
+    status = models.ForeignKey(
+        "Status", on_delete=models.CASCADE, related_name="tables"
+    )
+    publish_sql = models.CharField(max_length=10000, blank=True, null=True)
+    observation_level = models.ManyToManyField(
+        "ObservationLevel", related_name="tables", blank=True
+    )
     license = models.ForeignKey(
         "License", on_delete=models.CASCADE, related_name="tables"
     )
@@ -329,9 +336,6 @@ class Table(models.Model):
     compressed_file_size = models.BigIntegerField(blank=True, null=True)
     number_rows = models.BigIntegerField(blank=True, null=True)
     number_columns = models.BigIntegerField(blank=True, null=True)
-    observation_level = models.ManyToManyField(
-        "ObservationLevel", related_name="tables", blank=True
-    )
 
     def __str__(self):
         return f"{str(self.dataset.slug)}.{str(self.slug)}"

--- a/basedosdados_api/api/v1/models.py
+++ b/basedosdados_api/api/v1/models.py
@@ -239,7 +239,6 @@ class Organization(models.Model):
     facebook = models.URLField(blank=True, null=True)
     linkedin = models.URLField(blank=True, null=True)
     instagram = models.URLField(blank=True, null=True)
-    image = models.ImageField()
 
     def __str__(self):
         return str(self.slug)

--- a/basedosdados_api/api/v1/models.py
+++ b/basedosdados_api/api/v1/models.py
@@ -176,6 +176,7 @@ class Pipeline(models.Model):
 
 class AnalysisType(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
+    slug = models.SlugField(unique=True)
     name = models.CharField(max_length=255)
     tag = models.CharField(max_length=255)
 
@@ -210,7 +211,6 @@ class Theme(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
     slug = models.SlugField(unique=True)
     name = models.CharField(max_length=255)
-    logo_url = models.URLField()
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -226,14 +226,14 @@ class Theme(models.Model):
 
 class Organization(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
+    slug = models.SlugField(unique=True, max_length=255)
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, null=True)
     area = models.ForeignKey(
         "Area", on_delete=models.CASCADE, related_name="organizations"
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
-    slug = models.SlugField(unique=True, max_length=255)
-    name = models.CharField(max_length=255)
-    description = models.TextField(blank=True, null=True)
     website = models.URLField(blank=True, null=True)
     twitter = models.URLField(blank=True, null=True)
     facebook = models.URLField(blank=True, null=True)
@@ -252,6 +252,9 @@ class Organization(models.Model):
 
 class Dataset(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
+    slug = models.SlugField(unique=True, max_length=255)
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, null=True)
     organization = models.ForeignKey(
         "Organization", on_delete=models.CASCADE, related_name="datasets"
     )
@@ -259,9 +262,6 @@ class Dataset(models.Model):
     tags = models.ManyToManyField("Tag", related_name="datasets")
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
-    slug = models.SlugField(unique=True, max_length=255)
-    name = models.CharField(max_length=255)
-    description = models.TextField(blank=True, null=True)
 
     def __str__(self):
         return str(self.slug)
@@ -292,6 +292,9 @@ class UpdateFrequency(models.Model):
 
 class Table(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
+    slug = models.SlugField(unique=False)
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, null=True)
     dataset = models.ForeignKey(
         "Dataset", on_delete=models.CASCADE, related_name="tables"
     )
@@ -307,12 +310,15 @@ class Table(models.Model):
     pipeline = models.ForeignKey(
         "Pipeline", on_delete=models.CASCADE, related_name="tables"
     )
+    is_directory = models.BooleanField(default=False, blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
-    slug = models.SlugField(unique=False)
-    name = models.CharField(max_length=255)
-    description = models.TextField(blank=True, null=True)
-    is_directory = models.BooleanField(default=False, blank=True, null=True)
+    published_by = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name="tables"
+    )
+    data_cleaned_by = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name="tables"
+    )
     data_cleaning_description = models.TextField(blank=True, null=True)
     data_cleaning_code_url = models.URLField(blank=True, null=True)
     raw_data_url = models.URLField(blank=True, null=True, max_length=500)
@@ -344,7 +350,7 @@ class Table(models.Model):
 
 class BigQueryTypes(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
-    name = models.CharField(max_length=255, unique=True)
+    slug = models.SlugField(unique=False)
 
     def __str__(self):
         return str(self.name)
@@ -359,9 +365,12 @@ class BigQueryTypes(models.Model):
 class Column(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
     table = models.ForeignKey("Table", on_delete=models.CASCADE, related_name="columns")
+    name = models.CharField(max_length=255)
     bigquery_type = models.ForeignKey(
         "BigQueryTypes", on_delete=models.CASCADE, related_name="columns"
     )
+    description = models.TextField(blank=True, null=True)
+    covered_by_dictionary = models.BooleanField(default=False, blank=True, null=True)
     directory_primary_key = models.ForeignKey(
         "Column",
         on_delete=models.PROTECT,
@@ -369,14 +378,11 @@ class Column(models.Model):
         blank=True,
         null=True,
     )
-    name = models.CharField(max_length=255)
-    is_in_staging = models.BooleanField(default=True)
-    is_partition = models.BooleanField(default=False)
-    description = models.TextField(blank=True, null=True)
-    covered_by_dictionary = models.BooleanField(default=False, blank=True, null=True)
     measurement_unit = models.CharField(max_length=255, blank=True, null=True)
     contains_sensitive_data = models.BooleanField(default=False, blank=True, null=True)
     observations = models.TextField(blank=True, null=True)
+    is_in_staging = models.BooleanField(default=True)
+    is_partition = models.BooleanField(default=False)
 
     def __str__(self):
         return f"{str(self.table.dataset.slug)}.{self.table.slug}.{str(self.name)}"
@@ -468,6 +474,9 @@ class Language(models.Model):
 
 class RawDataSource(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, null=True)
+    url = models.URLField(max_length=500, blank=True, null=True)
     dataset = models.ForeignKey(
         "Dataset", on_delete=models.CASCADE, related_name="raw_data_sources"
     )
@@ -488,9 +497,6 @@ class RawDataSource(models.Model):
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
-    url = models.URLField(max_length=500, blank=True, null=True)
-    name = models.CharField(max_length=255)
-    description = models.TextField(blank=True, null=True)
     contains_structure_data = models.BooleanField(default=False)
     contains_api = models.BooleanField(default=False)
     is_free = models.BooleanField(default=False)
@@ -535,7 +541,7 @@ class InformationRequest(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     origin = models.TextField(max_length=500, blank=True, null=True)
-    slug = models.SlugField(unique=True, blank=True, null=True)
+    number = models.CharField(max_length=255)
     url = models.URLField(blank=True, max_length=500, null=True)
     started_at = models.DateTimeField(blank=True, null=True)
     data_url = models.URLField(max_length=500, blank=True, null=True)

--- a/basedosdados_api/api/v1/translation.py
+++ b/basedosdados_api/api/v1/translation.py
@@ -44,7 +44,7 @@ class DatasetTranslationOptions(TranslationOptions):
 
 
 class EntityTranslationOptions(TranslationOptions):
-    fields = ("name",)
+    fields = ("name","category")
 
 
 class InformationRequestTranslationOptions(TranslationOptions):

--- a/basedosdados_api/settings/base.py
+++ b/basedosdados_api/settings/base.py
@@ -206,6 +206,7 @@ GRAPHQL_JWT = {
 LANGUAGES = (
     ("pt", lambda x: "Português"),
     ("en", lambda x: "English"),
+    ("es", lambda x: "Español"),
 )
 
 MODELTRANSLATION_AUTO_POPULATE = True


### PR DESCRIPTION
## Changelog

* Criei o campo `entity.category` para representar esse [grupos do atual validator](https://github.com/basedosdados/website/blob/master/ckanext-basedosdados/ckanext/basedosdados/validator/available_options/entity.py).
* Ajustei campos de `area`.
* Limpei campos `slug` quando não precisavam.
* Adicionei o campo `number` em `information_request`.
* Adicionei `data_cleaned_by` e `published_by` em `table`. @AldemirLucas
* Campo `status` para `table`, já visando o novo fluxo de dados via site.
* Campo `publish_sql` para `table`, já visando o novo fluxo de dados via site.

## Tarefas
