### PR TITLE
Ajustes no search

### DIFF
--- a/basedosdados_api/api/v1/views.py
+++ b/basedosdados_api/api/v1/views.py
@@ -3,6 +3,7 @@ import json
 from typing import Dict, List, Tuple
 
 from django.http import HttpResponse, HttpResponseBadRequest, QueryDict
+from haystack.forms import ModelSearchForm
 from haystack.generic_views import SearchView
 
 from basedosdados_api.api.v1.models import Coverage, Dataset
@@ -15,10 +16,18 @@ class DatasetSearchView(SearchView):
         """
         # Get request arguments
         req_args: QueryDict = request.GET.copy()
-        form_class = self.get_form_class()
-        form = self.get_form(form_class)
+        query = req_args.get("q", None)
 
-        if form.is_valid():
+        # If query is empty, build dataset_list with all datasets
+        if not query:
+            dataset_list: List[Dataset] = list(Dataset.objects.all())
+
+        # If query is not empty, search for datasets
+        else:
+            form_class = self.get_form_class()
+            form: ModelSearchForm = self.get_form(form_class)
+            if not form.is_valid():
+                return HttpResponseBadRequest(json.dumps({"error": "Invalid form"}))
             self.queryset = form.search()
             context = self.get_context_data(
                 **{
@@ -29,230 +38,223 @@ class DatasetSearchView(SearchView):
             )
             # Raw dataset list
             dataset_list: List[Dataset] = [obj.object for obj in context["object_list"]]
-            # Filtering
-            if "theme" in req_args:
-                # Filter by theme slugs
-                theme_slugs = req_args.getlist("theme")
-                new_dataset_list = []
-                for dataset in dataset_list:
-                    for theme in dataset.themes.all():
-                        if theme.slug in theme_slugs:
-                            new_dataset_list.append(dataset)
-                            break
-                dataset_list = new_dataset_list
-            if "organization" in req_args:
-                # Filter by organization slugs
-                organization_slugs = req_args.getlist("organization")
-                dataset_list = [
-                    ds
-                    for ds in dataset_list
-                    if ds.organization.slug in organization_slugs
-                ]
-            if "tag" in req_args:
-                # Filter by tag slugs
-                tag_slugs = req_args.getlist("tag")
-                new_dataset_list = []
-                for dataset in dataset_list:
-                    for tag in dataset.tags.all():
-                        if tag.slug in tag_slugs:
-                            new_dataset_list.append(dataset)
-                            break
-                dataset_list = new_dataset_list
-            if "spatial_coverage" in req_args or "temporal_coverage" in req_args:
-                # Collect all coverage objects
-                coverages: Dict[str, List[Coverage]] = {}
-                added_coverages = set()
-                for dataset in dataset_list:
-                    for table in dataset.tables.all():
-                        for coverage in table.coverages.all():
-                            if coverage.id not in added_coverages:
-                                if dataset.slug not in coverages:
-                                    coverages[dataset.slug] = []
-                                coverages[dataset.slug].append(coverage)
-                                added_coverages.add(coverage.id)
-                    for raw_data_source in dataset.raw_data_sources.all():
-                        for coverage in raw_data_source.coverages.all():
-                            if coverage.id not in added_coverages:
-                                if dataset.slug not in coverages:
-                                    coverages[dataset.slug] = []
-                                coverages[dataset.slug].append(coverage)
-                                added_coverages.add(coverage.id)
-                    for information_request in dataset.information_requests.all():
-                        for coverage in information_request.coverages.all():
-                            if coverage.id not in added_coverages:
-                                if dataset.slug not in coverages:
-                                    coverages[dataset.slug] = []
-                                coverages[dataset.slug].append(coverage)
-                                added_coverages.add(coverage.id)
-            if "spatial_coverage" in req_args:
-                # Filter by spatial coverages
-                spatial_coverages = req_args.getlist("spatial_coverage")
-                new_dataset_list = []
-                added_datasets = set()
-                for dataset in dataset_list:
-                    if dataset.slug in coverages:
-                        for coverage in coverages[dataset.slug]:
-                            for spatial_coverage in spatial_coverages:
-                                if coverage.area.slug.startswith(spatial_coverage):
-                                    new_dataset_list.append(dataset)
-                                    added_datasets.add(dataset.slug)
-                                    break
-                            if dataset.slug in added_datasets:
-                                break
-                dataset_list = new_dataset_list
-            if "temporal_coverage" in req_args:
-                # Filter by temporal coverage
-                temporal_coverage = req_args["temporal_coverage"]
-                start_year, end_year = temporal_coverage.split("-")
-                start_year = int(start_year)
-                end_year = int(end_year)
-                new_dataset_list = []
-                added_datasets = set()
-                for dataset in dataset_list:
-                    if dataset.slug in coverages:
-                        for coverage in coverages[dataset.slug]:
-                            for datetime_range in coverage.datetime_ranges.all():
-                                if (
-                                    datetime_range.start_year <= start_year
-                                    and datetime_range.end_year >= end_year
-                                ):
-                                    new_dataset_list.append(dataset)
-                                    added_datasets.add(dataset.slug)
-                                    break
-                            if dataset.slug in added_datasets:
-                                break
-                dataset_list = new_dataset_list
-            if "entity" in req_args:
-                # Collect all entities
-                entities: Dict[str, List[str]] = {}
-                added_entities = set()
-                for dataset in dataset_list:
-                    for table in dataset.tables.all():
-                        for observation_level in table.observation_levels.all():
-                            entity = observation_level.entity
-                            if entity.id not in added_entities:
-                                if dataset.slug not in entities:
-                                    entities[dataset.slug] = []
-                                entities[dataset.slug].append(entity.slug)
-                                added_entities.add(entity.id)
-                    for raw_data_source in dataset.raw_data_sources.all():
-                        for (
-                            observation_level
-                        ) in raw_data_source.observation_levels.all():
-                            entity = observation_level.entity
-                            if entity.id not in added_entities:
-                                if dataset.slug not in entities:
-                                    entities[dataset.slug] = []
-                                entities[dataset.slug].append(entity.slug)
-                                added_entities.add(entity.id)
-                    for information_request in dataset.information_requests.all():
-                        for (
-                            observation_level
-                        ) in information_request.observation_levels.all():
-                            entity = observation_level.entity
-                            if entity.id not in added_entities:
-                                if dataset.slug not in entities:
-                                    entities[dataset.slug] = []
-                                entities[dataset.slug].append(entity.slug)
-                                added_entities.add(entity.id)
-                # Filter by entity slugs
-                entity_slugs = req_args.getlist("entity")
-                new_dataset_list = []
-                for dataset in dataset_list:
-                    for entity_slug in entity_slugs:
-                        if (
-                            dataset.slug in entities
-                            and entity_slug in entities[dataset.slug]
-                        ):
-                            new_dataset_list.append(dataset)
-                            break
-                dataset_list = new_dataset_list
-            if "update_frequency" in req_args:
-                update_frequencies: List[Tuple[int, str]] = [
-                    self.split_number_text(frequency)
-                    for frequency in req_args.getlist("update_frequency")
-                ]
-                # Collect all updates
-                updates: Dict[str, List[Tuple[int, str]]] = {}
-                added_updates = set()
-                for dataset in dataset_list:
-                    for table in dataset.tables.all():
-                        for update in table.updates.all():
-                            if update.id not in added_updates:
-                                if dataset.slug not in updates:
-                                    updates[dataset.slug] = []
-                                updates[dataset.slug].append(
-                                    (update.frequency, update.entity.slug)
-                                )
-                                added_updates.add(update.id)
-                    for raw_data_source in dataset.raw_data_sources.all():
-                        for update in raw_data_source.updates.all():
-                            if update.id not in added_updates:
-                                if dataset.slug not in updates:
-                                    updates[dataset.slug] = []
-                                updates[dataset.slug].append(
-                                    (update.frequency, update.entity.slug)
-                                )
-                                added_updates.add(update.id)
-                    for information_request in dataset.information_requests.all():
-                        for update in information_request.updates.all():
-                            if update.id not in added_updates:
-                                if dataset.slug not in updates:
-                                    updates[dataset.slug] = []
-                                updates[dataset.slug].append(
-                                    (update.frequency, update.entity.slug)
-                                )
-                                added_updates.add(update.id)
-                # Filter by update frequencies
-                new_dataset_list = []
-                for dataset in dataset_list:
-                    for update_frequency in update_frequencies:
-                        if (
-                            dataset.slug in updates
-                            and update_frequency in updates[dataset.slug]
-                        ):
-                            new_dataset_list.append(dataset)
-                            break
-                dataset_list = new_dataset_list
-            if "raw_quality_tier" in req_args:
-                # TODO: filter by raw quality tier
-                ...
-            # Pagination
-            try:
-                if "page_size" in req_args:
-                    page_size = int(req_args["page_size"])
-                else:
-                    page_size = 10
-                if page_size < 1:
-                    raise ValueError("page_size must be greater than 0")
-            except:  # noqa
-                return HttpResponseBadRequest(
-                    json.dumps({"error": "Invalid page_size"})
-                )
-            try:
-                if "page" in req_args:
-                    page = int(req_args["page"])
-                else:
-                    page = 1
-                if page < 1:
-                    raise ValueError("page must be greater than 0")
-            except:  # noqa
-                return HttpResponseBadRequest(json.dumps({"error": "Invalid page"}))
-            page_dataset_list = dataset_list[
-                (page - 1) * page_size : page * page_size  # noqa
+
+        # Filtering
+        if "theme" in req_args:
+            # Filter by theme slugs
+            theme_slugs = req_args.getlist("theme")
+            new_dataset_list = []
+            for dataset in dataset_list:
+                for theme in dataset.themes.all():
+                    if theme.slug in theme_slugs:
+                        new_dataset_list.append(dataset)
+                        break
+            dataset_list = new_dataset_list
+        if "organization" in req_args:
+            # Filter by organization slugs
+            organization_slugs = req_args.getlist("organization")
+            dataset_list = [
+                ds for ds in dataset_list if ds.organization.slug in organization_slugs
             ]
-            results = [self.serialize_dataset(ds) for ds in page_dataset_list]
-            return HttpResponse(
-                json.dumps(
-                    {
-                        "count": len(dataset_list),
-                        "results": results,
-                    }
-                ),
-                status=200 if len(results) > 0 else 204,
-            )
-        else:
-            return HttpResponseBadRequest(json.dumps({"error": "Invalid form"}))
+        if "tag" in req_args:
+            # Filter by tag slugs
+            tag_slugs = req_args.getlist("tag")
+            new_dataset_list = []
+            for dataset in dataset_list:
+                for tag in dataset.tags.all():
+                    if tag.slug in tag_slugs:
+                        new_dataset_list.append(dataset)
+                        break
+            dataset_list = new_dataset_list
+        if "spatial_coverage" in req_args or "temporal_coverage" in req_args:
+            # Collect all coverage objects
+            coverages: Dict[str, List[Coverage]] = {}
+            added_coverages = set()
+            for dataset in dataset_list:
+                for table in dataset.tables.all():
+                    for coverage in table.coverages.all():
+                        if coverage.id not in added_coverages:
+                            if dataset.slug not in coverages:
+                                coverages[dataset.slug] = []
+                            coverages[dataset.slug].append(coverage)
+                            added_coverages.add(coverage.id)
+                for raw_data_source in dataset.raw_data_sources.all():
+                    for coverage in raw_data_source.coverages.all():
+                        if coverage.id not in added_coverages:
+                            if dataset.slug not in coverages:
+                                coverages[dataset.slug] = []
+                            coverages[dataset.slug].append(coverage)
+                            added_coverages.add(coverage.id)
+                for information_request in dataset.information_requests.all():
+                    for coverage in information_request.coverages.all():
+                        if coverage.id not in added_coverages:
+                            if dataset.slug not in coverages:
+                                coverages[dataset.slug] = []
+                            coverages[dataset.slug].append(coverage)
+                            added_coverages.add(coverage.id)
+        if "spatial_coverage" in req_args:
+            # Filter by spatial coverages
+            spatial_coverages = req_args.getlist("spatial_coverage")
+            new_dataset_list = []
+            added_datasets = set()
+            for dataset in dataset_list:
+                if dataset.slug in coverages:
+                    for coverage in coverages[dataset.slug]:
+                        for spatial_coverage in spatial_coverages:
+                            if coverage.area.slug.startswith(spatial_coverage):
+                                new_dataset_list.append(dataset)
+                                added_datasets.add(dataset.slug)
+                                break
+                        if dataset.slug in added_datasets:
+                            break
+            dataset_list = new_dataset_list
+        if "temporal_coverage" in req_args:
+            # Filter by temporal coverage
+            temporal_coverage = req_args["temporal_coverage"]
+            start_year, end_year = temporal_coverage.split("-")
+            start_year = int(start_year)
+            end_year = int(end_year)
+            new_dataset_list = []
+            added_datasets = set()
+            for dataset in dataset_list:
+                if dataset.slug in coverages:
+                    for coverage in coverages[dataset.slug]:
+                        for datetime_range in coverage.datetime_ranges.all():
+                            if (
+                                datetime_range.start_year <= start_year
+                                and datetime_range.end_year >= end_year
+                            ):
+                                new_dataset_list.append(dataset)
+                                added_datasets.add(dataset.slug)
+                                break
+                        if dataset.slug in added_datasets:
+                            break
+            dataset_list = new_dataset_list
+        if "entity" in req_args:
+            # Collect all entities
+            entities: Dict[str, List[str]] = {}
+            added_entities = set()
+            for dataset in dataset_list:
+                for table in dataset.tables.all():
+                    for observation_level in table.observation_levels.all():
+                        entity = observation_level.entity
+                        if entity.id not in added_entities:
+                            if dataset.slug not in entities:
+                                entities[dataset.slug] = []
+                            entities[dataset.slug].append(entity.slug)
+                            added_entities.add(entity.id)
+                for raw_data_source in dataset.raw_data_sources.all():
+                    for observation_level in raw_data_source.observation_levels.all():
+                        entity = observation_level.entity
+                        if entity.id not in added_entities:
+                            if dataset.slug not in entities:
+                                entities[dataset.slug] = []
+                            entities[dataset.slug].append(entity.slug)
+                            added_entities.add(entity.id)
+                for information_request in dataset.information_requests.all():
+                    for (
+                        observation_level
+                    ) in information_request.observation_levels.all():
+                        entity = observation_level.entity
+                        if entity.id not in added_entities:
+                            if dataset.slug not in entities:
+                                entities[dataset.slug] = []
+                            entities[dataset.slug].append(entity.slug)
+                            added_entities.add(entity.id)
+            # Filter by entity slugs
+            entity_slugs = req_args.getlist("entity")
+            new_dataset_list = []
+            for dataset in dataset_list:
+                for entity_slug in entity_slugs:
+                    if (
+                        dataset.slug in entities
+                        and entity_slug in entities[dataset.slug]
+                    ):
+                        new_dataset_list.append(dataset)
+                        break
+            dataset_list = new_dataset_list
+        if "update_frequency" in req_args:
+            update_frequencies: List[Tuple[int, str]] = [
+                self.split_number_text(frequency)
+                for frequency in req_args.getlist("update_frequency")
+            ]
+            # Collect all updates
+            updates: Dict[str, List[Tuple[int, str]]] = {}
+            added_updates = set()
+            for dataset in dataset_list:
+                for table in dataset.tables.all():
+                    for update in table.updates.all():
+                        if update.id not in added_updates:
+                            if dataset.slug not in updates:
+                                updates[dataset.slug] = []
+                            updates[dataset.slug].append(
+                                (update.frequency, update.entity.slug)
+                            )
+                            added_updates.add(update.id)
+                for raw_data_source in dataset.raw_data_sources.all():
+                    for update in raw_data_source.updates.all():
+                        if update.id not in added_updates:
+                            if dataset.slug not in updates:
+                                updates[dataset.slug] = []
+                            updates[dataset.slug].append(
+                                (update.frequency, update.entity.slug)
+                            )
+                            added_updates.add(update.id)
+                for information_request in dataset.information_requests.all():
+                    for update in information_request.updates.all():
+                        if update.id not in added_updates:
+                            if dataset.slug not in updates:
+                                updates[dataset.slug] = []
+                            updates[dataset.slug].append(
+                                (update.frequency, update.entity.slug)
+                            )
+                            added_updates.add(update.id)
+            # Filter by update frequencies
+            new_dataset_list = []
+            for dataset in dataset_list:
+                for update_frequency in update_frequencies:
+                    if (
+                        dataset.slug in updates
+                        and update_frequency in updates[dataset.slug]
+                    ):
+                        new_dataset_list.append(dataset)
+                        break
+            dataset_list = new_dataset_list
+        if "raw_quality_tier" in req_args:
+            # TODO: filter by raw quality tier
+            ...
+        # Pagination
+        try:
+            if "page_size" in req_args:
+                page_size = int(req_args["page_size"])
+            else:
+                page_size = 10
+            if page_size < 1:
+                raise ValueError("page_size must be greater than 0")
+        except:  # noqa
+            return HttpResponseBadRequest(json.dumps({"error": "Invalid page_size"}))
+        try:
+            if "page" in req_args:
+                page = int(req_args["page"])
+            else:
+                page = 1
+            if page < 1:
+                raise ValueError("page must be greater than 0")
+        except:  # noqa
+            return HttpResponseBadRequest(json.dumps({"error": "Invalid page"}))
+        page_dataset_list = dataset_list[
+            (page - 1) * page_size : page * page_size  # noqa
+        ]
+        results = [self.serialize_dataset(ds) for ds in page_dataset_list]
+        return HttpResponse(
+            json.dumps(
+                {
+                    "count": len(dataset_list),
+                    "results": results,
+                }
+            ),
+            status=200 if len(results) > 0 else 204,
+        )
 
     def serialize_dataset(self, dataset: Dataset):
         def get_temporal_coverage(dataset: Dataset) -> str:

--- a/basedosdados_api/api/v1/views.py
+++ b/basedosdados_api/api/v1/views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 from django.http import HttpResponse, HttpResponseBadRequest, QueryDict
 from haystack.forms import ModelSearchForm
@@ -356,16 +356,59 @@ class DatasetSearchView(SearchView):
                 return f"{min_year}"
             return f"{min_year}-{max_year}"
 
+        def get_themes(dataset: Dataset) -> List[Dict[str, str]]:
+            themes = []
+            for theme in dataset.themes.all():
+                themes.append(
+                    {
+                        "name": theme.name,
+                        "slug": theme.slug,
+                    }
+                )
+            return themes
+
+        def get_tags(dataset: Dataset) -> List[Dict[str, str]]:
+            tags = []
+            for tag in dataset.tags.all():
+                tags.append(
+                    {
+                        "name": tag.name,
+                        "slug": tag.slug,
+                    }
+                )
+            return tags
+
+        def get_first_table_id(dataset: Dataset) -> Union[str, None]:
+            if dataset.tables.count() > 0:
+                return str(dataset.tables.first().id)
+            return None
+
+        def get_first_original_source_id(dataset: Dataset) -> Union[str, None]:
+            if dataset.raw_data_sources.count() > 0:
+                return str(dataset.raw_data_sources.first().id)
+            return None
+
+        def get_first_lai_id(dataset: Dataset) -> Union[str, None]:
+            if dataset.information_requests.count() > 0:
+                return str(dataset.information_requests.first().id)
+            return None
+
         return {
             "id": str(dataset.id),
             "slug": dataset.slug,
             "full_slug": dataset.full_slug,
             "name": dataset.name,
             "organization": dataset.organization.name,
+            "organization_slug": dataset.organization.slug,
+            "themes": get_themes(dataset),
+            "tags": get_tags(dataset),
             "temporal_coverage": get_temporal_coverage(dataset),
             "n_bdm_tables": dataset.tables.count(),
+            "first_table_id": get_first_table_id(dataset),
             "n_original_sources": dataset.raw_data_sources.count(),
+            "first_original_source_id": get_first_original_source_id(dataset),
             "n_lais": dataset.information_requests.count(),
+            "first_lai_id": get_first_lai_id(dataset),
         }
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Relacionado a #113 e chat com @AldemirLucas 

### Modificações:
- Não informar uma query agora no parametro `q` implica em retornar uma lista de todos os datasets (filtros são aplicáveis)
- Adiciona um parâmetro `filter_method`, que tem valor padrão `and` e tem valores possíveis `['and', 'or']`, para dizer se o filtro deve ser inclusivo ou exclusivo.
  - `and` não é suportado para múltiplas `organization`. Caso seja solicitado, retornará um _Bad Request_
  - `and` não é suportado para múltiplas `update_frequency`. Caso seja solicitado, retornará um _Bad Request_
- Adiciona os seguintes campos na serialização do dataset:
  - Slug da `organization`
  - Lista de temas no formato `{"name": "nome do tema", "slug": "slug_do_tema"}`
  - Lista de tags no formato `{"name": "nome da tag", "slug": "slug_da_tag"}`
  - ID da primeira `table` do `dataset` (caso exista, caso contrário `null`)
  - ID do primeiro `raw_data_source` do `dataset` (caso exista, caso contrário `null`)
  - ID do primeiro `information_request` do `dataset` (caso exista, caso contrário `null`)