### PR TITLE
[FEATURE] Markdown no Django Admin

### DIFF
--- a/basedosdados_api/account/admin.py
+++ b/basedosdados_api/account/admin.py
@@ -198,7 +198,14 @@ class BDGroupRoleInline(admin.TabularInline):
     extra = 1
 
 
+from martor.widgets import AdminMartorWidget
+from django.db import models
+
+
 class BDGroupAdmin(admin.ModelAdmin):
+    formfield_overrides = {
+        models.TextField: {"widget": AdminMartorWidget},
+    }
     inlines = (BDGroupRoleInline,)
     list_display = ("name", "description")
     search_fields = ("name", "description")

--- a/basedosdados_api/settings/base.py
+++ b/basedosdados_api/settings/base.py
@@ -40,6 +40,8 @@ CORS_ORIGIN_ALLOW_ALL = True
 INSTALLED_APPS = [
     "modeltranslation",
     "jazzmin",
+    "martor",
+    "django_extensions",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -262,3 +264,57 @@ JAZZMIN_SETTINGS = {
     ],
     "show_ui_builder": True,
 }
+
+
+MARTOR_THEME = 'bootstrap'
+MARTOR_ENABLE_CONFIGS = {
+    'emoji': 'true',        # to enable/disable emoji icons.
+    'imgur': 'false',       # to enable/disable imgur/custom uploader.
+    'mention': 'false',     # to enable/disable mention
+    'jquery': 'true',       # to include/revoke jquery (require for admin default django)
+    'living': 'false',      # to enable/disable live updates in preview
+    'spellcheck': 'false',  # to enable/disable spellcheck in form textareas
+    'hljs': 'true',         # to enable/disable hljs highlighting in preview
+}
+MARTOR_TOOLBAR_BUTTONS = [
+    'bold', 'italic', 'horizontal', 'heading', 'pre-code',
+    'blockquote', 'unordered-list', 'ordered-list',
+    'link', 'image-link', 'image-upload', 'emoji',
+    'direct-mention', 'toggle-maximize', 'help'
+]
+MARTOR_MARKDOWNIFY_FUNCTION = 'martor.utils.markdownify' # default
+MARTOR_MARKDOWNIFY_URL = '/martor/markdownify/' # default
+MARTOR_MARKDOWN_EXTENSIONS = [
+    'markdown.extensions.extra',
+    'markdown.extensions.nl2br',
+    'markdown.extensions.smarty',
+    'markdown.extensions.fenced_code',
+
+    # Custom markdown extensions.
+    'martor.extensions.urlize',
+    'martor.extensions.del_ins',      # ~~strikethrough~~ and ++underscores++
+    'martor.extensions.mention',      # to parse markdown mention
+    'martor.extensions.emoji',        # to parse markdown emoji
+    'martor.extensions.mdx_video',    # to parse embed/iframe video
+    'martor.extensions.escape_html',  # to handle the XSS vulnerabilities
+]
+MARTOR_MARKDOWN_EXTENSION_CONFIGS = {}
+MARTOR_UPLOAD_URL = '' # Completely disable the endpoint
+MARTOR_SEARCH_USERS_URL = '' # Completely disables the endpoint
+MARTOR_MARKDOWN_BASE_EMOJI_URL = 'https://github.githubassets.com/images/icons/emoji/'                  # default from github
+ALLOWED_HTML_TAGS = [
+    "a", "abbr", "b", "blockquote", "br", "cite", "code", "command",
+    "dd", "del", "dl", "dt", "em", "fieldset", "h1", "h2", "h3", "h4", "h5", "h6",
+    "hr", "i", "iframe", "img", "input", "ins", "kbd", "label", "legend",
+    "li", "ol", "optgroup", "option", "p", "pre", "small", "span", "strong",
+    "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "u", "ul"
+]
+
+# https://github.com/decal/werdlists/blob/master/html-words/html-attributes-list.txt
+ALLOWED_HTML_ATTRIBUTES = [
+    "alt", "class", "color", "colspan", "datetime",  # "data",
+    "height", "href", "id", "name", "reversed", "rowspan",
+    "scope", "src", "style", "title", "type", "width"
+]
+
+CSRF_COOKIE_HTTPONLY = False

--- a/basedosdados_api/settings/base.py
+++ b/basedosdados_api/settings/base.py
@@ -41,7 +41,6 @@ INSTALLED_APPS = [
     "modeltranslation",
     "jazzmin",
     "martor",
-    "django_extensions",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/basedosdados_api/settings/dev.py
+++ b/basedosdados_api/settings/dev.py
@@ -13,6 +13,8 @@ def nonull_getenv(var):
     return value
 
 
+CSRF_TRUSTED_ORIGINS = ["http://localhost:3000", "http://localhost:8000"]
+
 # Database
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
 

--- a/basedosdados_api/urls.py
+++ b/basedosdados_api/urls.py
@@ -39,6 +39,7 @@ def redirect_to_v1_graphql(request):
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("martor/", include("martor.urls")),
     path("account/", include("basedosdados_api.account.urls")),
     re_path(r"^healthcheck/", include("health_check.urls")),
     path("api/", redirect_to_v1, name="api"),

--- a/poetry.lock
+++ b/poetry.lock
@@ -86,6 +86,25 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "bleach"
+version = "6.0.0"
+description = "An easy safelist-based HTML-sanitizing tool."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "bleach-6.0.0-py3-none-any.whl", hash = "sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4"},
+    {file = "bleach-6.0.0.tar.gz", hash = "sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414"},
+]
+
+[package.dependencies]
+six = ">=1.9.0"
+webencodings = "*"
+
+[package.extras]
+css = ["tinycss2 (>=1.1.0,<1.2)"]
+
+[[package]]
 name = "cachetools"
 version = "5.3.0"
 description = "Extensible memoizing collections and decorators"
@@ -291,6 +310,21 @@ python-versions = ">=3.7"
 files = [
     {file = "django_cors_headers-3.14.0-py3-none-any.whl", hash = "sha256:684180013cc7277bdd8702b80a3c5a4b3fcae4abb2bf134dceb9f5dfe300228e"},
     {file = "django_cors_headers-3.14.0.tar.gz", hash = "sha256:5fbd58a6fb4119d975754b2bc090f35ec160a8373f276612c675b00e8a138739"},
+]
+
+[package.dependencies]
+Django = ">=3.2"
+
+[[package]]
+name = "django-extensions"
+version = "3.2.1"
+description = "Extensions for Django"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "django-extensions-3.2.1.tar.gz", hash = "sha256:2a4f4d757be2563cd1ff7cfdf2e57468f5f931cc88b23cf82ca75717aae504a4"},
+    {file = "django_extensions-3.2.1-py3-none-any.whl", hash = "sha256:421464be390289513f86cb5e18eb43e5dc1de8b4c27ba9faa3b91261b0d67e09"},
 ]
 
 [package.dependencies]
@@ -982,6 +1016,38 @@ files = [
     {file = "lazy_object_proxy-1.9.0-cp39-cp39-win32.whl", hash = "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821"},
     {file = "lazy_object_proxy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f"},
 ]
+
+[[package]]
+name = "markdown"
+version = "3.3.4"
+description = "Python implementation of Markdown."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "Markdown-3.3.4-py3-none-any.whl", hash = "sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c"},
+    {file = "Markdown-3.3.4.tar.gz", hash = "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49"},
+]
+
+[package.extras]
+testing = ["coverage", "pyyaml"]
+
+[[package]]
+name = "martor"
+version = "1.6.26"
+description = "Django Markdown Editor"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "martor-1.6.26.tar.gz", hash = "sha256:f44af117695b5b62c002e1c67a727b46ece9d9662738d551ded018611b8bfc86"},
+]
+
+[package.dependencies]
+bleach = "*"
+Django = ">=3.2"
+Markdown = "3.3.4"
+requests = "*"
 
 [[package]]
 name = "mccabe"
@@ -1700,6 +1766,18 @@ docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.7.1)", "time-machine (>=2.9)"]
 
 [[package]]
+name = "webencodings"
+version = "0.5.1"
+description = "Character encoding aliases for legacy web content"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
+    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
+
+[[package]]
 name = "wrapt"
 version = "1.15.0"
 description = "Module for decorators, wrappers and monkey patching."
@@ -1787,4 +1865,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e085f8ac367c1574434d147c12f74430cb10ffcb68c2add85d932d1ef4cf7515"
+content-hash = "a67dc4e205b989e4fd48913a7934befd7fff578f2189c31d8d574393e4423f99"

--- a/poetry.lock
+++ b/poetry.lock
@@ -316,21 +316,6 @@ files = [
 Django = ">=3.2"
 
 [[package]]
-name = "django-extensions"
-version = "3.2.1"
-description = "Extensions for Django"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "django-extensions-3.2.1.tar.gz", hash = "sha256:2a4f4d757be2563cd1ff7cfdf2e57468f5f931cc88b23cf82ca75717aae504a4"},
-    {file = "django_extensions-3.2.1-py3-none-any.whl", hash = "sha256:421464be390289513f86cb5e18eb43e5dc1de8b4c27ba9faa3b91261b0d67e09"},
-]
-
-[package.dependencies]
-Django = ">=3.2"
-
-[[package]]
 name = "django-filter"
 version = "22.1"
 description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
@@ -1865,4 +1850,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a67dc4e205b989e4fd48913a7934befd7fff578f2189c31d8d574393e4423f99"
+content-hash = "bf15f05cdee8a0f2e7e5b904f4d707de41162de1b6a5d1bbb89075c504204769"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ django-storages = {extras = ["google"], version = "^1.13.2"}
 google-api-python-client = "^2.83.0"
 django-jazzmin = "^2.6.0"
 martor = "^1.6.26"
-django-extensions = "^3.2.1"
+
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ graphene = "3.2.1"
 django-storages = {extras = ["google"], version = "^1.13.2"}
 google-api-python-client = "^2.83.0"
 django-jazzmin = "^2.6.0"
+martor = "^1.6.26"
+django-extensions = "^3.2.1"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"


### PR DESCRIPTION
Adiciona funcionalidade básica de Markdown para edição de campos do Django Admin.


Esse MR permite que escolhamos utilizar o markdown no django admin, porém não implementa universalmente em todos os campos no admin.

é necessário escolher quais campos permitiram essa utilização.  