### PR TITLE
Quando em dev, cria exceção de CSRF, para podermos rodar dentro do docker.

### DIFF
--- a/basedosdados_api/settings/dev.py
+++ b/basedosdados_api/settings/dev.py
@@ -24,6 +24,7 @@ DATABASES = {
 }
 
 LOGGING = DEFAULT_LOGGING
+CSRF_TRUSTED_ORIGINS = ["http://localhost:8080"]
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = "smtp.gmail.com"


### PR DESCRIPTION
Quando roda-se o django dentro do compose (docker compose up), ao tentar logar no ADMIN, toma-se erro 403, csrf falhou.


Acredito ser por conta do NGINX que fica na frente do django.
Para permitir que rodemos tudo dentro do docker compose, adicionei essa config em dev. 
8080 refere-se a porta do serviço "api"

Dev, imagino eu, não deve rodar em prod, portanto não representa risco.