### PR TITLE
expires GCS key in 7 days

### DIFF
--- a/basedosdados_api/settings/prod.py
+++ b/basedosdados_api/settings/prod.py
@@ -58,3 +58,4 @@ GS_CREDENTIALS = service_account.Credentials.from_service_account_info(
 )
 DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 GS_BUCKET_NAME = nonull_getenv("GCP_BUCKET_NAME")
+GS_EXPIRATION = timedelta(seconds=604800)  # noqa: F405


### PR DESCRIPTION
A indexação das imagens é fundamental para melhoria do tempo da busca. Porém, o GCS exige que a chave expire em, no máximo, 7 dias. Assim, temos as seguintes soluções:

- rodar a reindexação toda semana
- colocar o bucket público
- se possível, colocar apenas as imagens de organização públicas.

@lucascr91 @JoaoCarabetta @rdahis @gabriel-milan @guialvesp1 