### PR TITLE
hotfix: do not raise error when all coverages have no datetime_ranges

### DIFF
--- a/basedosdados_api/api/v1/models.py
+++ b/basedosdados_api/api/v1/models.py
@@ -1099,9 +1099,12 @@ class Table(BdmModel, OrderedModel):
             coverages = self.coverages.all()
             temporal_coverages_by_area = {str(coverage.area.slug): [] for coverage in coverages}
             for coverage in coverages:
-                temporal_coverages_by_area[str(coverage.area.slug)].append(
-                    *list(coverage.datetime_ranges.all())
-                )
+                try:
+                    temporal_coverages_by_area[str(coverage.area.slug)].append(
+                        *list(coverage.datetime_ranges.all())
+                    )
+                except TypeError:
+                    continue
             for area, temporal_coverages in temporal_coverages_by_area.items():
                 dt_ranges = []
                 for _, temporal_coverage in enumerate(temporal_coverages):

--- a/basedosdados_api/api/v1/tests/test_models.py
+++ b/basedosdados_api/api/v1/tests/test_models.py
@@ -127,31 +127,6 @@ def test_table_create(tabela_bairros):
 
 
 @pytest.mark.django_db
-def test_table_create_with_overlapping_coverage(
-    tabela_pro,
-    coverage_tabela_open,
-    coverage_tabela_closed,
-    datetime_range_1,
-    datetime_range_2,
-):
-    """
-    Test for Table with Coverage containing overlapping DateTimeRange.
-    The overlapping DateTimeRange must have the same area.
-    Must raise ValidationError.
-    """
-    tabela_pro.save()
-    coverage_tabela_open.save()
-    datetime_range_1.coverage = coverage_tabela_open
-    datetime_range_1.save()
-
-    datetime_range_2.coverage = coverage_tabela_closed
-    datetime_range_2.save()
-    with pytest.raises(ValidationError):
-        tabela_pro.coverages.add(coverage_tabela_open, coverage_tabela_closed)
-        tabela_pro.clean()
-
-
-@pytest.mark.django_db
 def test_table_with_empty_coverage(tabela_bairros, coverage_tabela_open, datetime_range_empty):
     """
     Test for Table with Coverage containing no DateTimeRange.

--- a/basedosdados_api/api/v1/tests/test_table_coverage.py
+++ b/basedosdados_api/api/v1/tests/test_table_coverage.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+Pytest Django models tests.
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from basedosdados_api.api.v1.models import Table
+
+
+@pytest.mark.django_db
+def test_table_coverage_with_no_date_time_range(
+    tabela_bairros,
+    coverage_tabela_open,
+):
+    """
+    Test for validating a coverage with no datetime_range.
+    """
+    coverage_tabela_open.save()
+
+    tabela_bairros.clean()
+    tabela_bairros.save()
+
+    assert Table.objects.exists()
+
+
+@pytest.mark.django_db
+def test_table_create_with_overlapping_coverage(
+    tabela_pro,
+    coverage_tabela_open,
+    coverage_tabela_closed,
+    datetime_range_1,
+    datetime_range_2,
+):
+    """
+    Test for Table with Coverage containing overlapping DateTimeRange.
+    Overlapping DateTimeRange in the same Coverage area ust raise ValidationError.
+    """
+    tabela_pro.save()
+    coverage_tabela_open.save()
+    datetime_range_1.coverage = coverage_tabela_open
+    datetime_range_1.save()
+
+    datetime_range_2.coverage = coverage_tabela_closed
+    datetime_range_2.save()
+    with pytest.raises(ValidationError):
+        tabela_pro.coverages.add(coverage_tabela_open, coverage_tabela_closed)
+        tabela_pro.clean()


### PR DESCRIPTION
### Purpose

Correct bug in table coverages validation

### Description

Overlapping datetime_ranges must be validated by `Table`, instead of by `Coverage` and a `DateTimeRange` is not mandatory in `Coverage`. In situations where all table coverages had no datetime_ranges it raised an error that should not happen.

### Checklist

<!-- Make sure the checkboxes reflect the actions you've taken -->

- [x] I have reviewed the code changes.
- [x] I have tested the changes locally.
- [x] I have updated the documentation if needed.
- [x] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

Created a new test file with this case. One of the previous tests was moved to this file, as it correlates

### Next steps

Rearrange all tests to be grouped by similarity
