### PR TITLE
fix: ignore account post save signal in fixture loading

### DIFF
--- a/basedosdados_api/account/signals.py
+++ b/basedosdados_api/account/signals.py
@@ -12,9 +12,9 @@ from basedosdados_api.settings import EMAIL_HOST_USER
 
 
 @receiver(post_save, sender=Account)
-def send_activation_email(sender, instance, created, **kwargs):
-    """Send activation email to instance after registration"""
-    if created:
+def send_activation_email(sender, instance, created, raw, **kwargs):
+    """Send activation email to instance after registration, not fixtures"""
+    if created and not raw:
         to_email = instance.email
         from_email = EMAIL_HOST_USER
         subject = "Bem Vindo à Base dos Dados!"


### PR DESCRIPTION
<!--- You can modify it as per your needs -->

### Purpose

- Avoid sending emails on fixture loading

### Description

- Ignore account post save signal in fixture loading

### Checklist

<!-- Make sure the checkboxes reflect the actions you've taken -->

- [x] I have reviewed the code changes.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

![image](https://github.com/basedosdados/backend/assets/4673693/aa8e994e-b668-4ac9-af97-dca2b4e23eca)

### Next steps

<!--- Describe further actions, if any, needed to complete the implementation  -->
