### PR TITLE
fix: read dev branch name with script

### DIFF
--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -40,18 +40,13 @@ jobs:
         run: unzip artifact.zip
 
       - name: Read branch name
-        uses: actions/github-script@v6
         id: extract_branch
-        with:
-          script: |
-            let fs = require('fs');
-            let branch = fs.readFileSync('./branch', 'utf8');
-            return branch;
+        run: echo "branch=$(cat branch)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.extract_branch.outputs.result }}
+          ref: ${{ steps.extract_branch.outputs.branch }}
 
       - name: Import secrets from Vault
         id: import_secrets


### PR DESCRIPTION
<!--- You can modify it as per your needs -->

### Purpose

- Avoid this [release bug](https://github.com/basedosdados/backend/actions/runs/6179055937/job/16773334493)

### Description

- Use bash script to read pr branch name

### Checklist

<!-- Make sure the checkboxes reflect the actions you've taken -->

- [ ] I have reviewed the code changes.
- [ ] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

<!-- Include relevant screenshots or images that help visualize the changes. -->

### Next steps

<!--- Describe further actions, if any, needed to complete the implementation  -->
