### PR TITLE
fix: set deploy staging branch to main

### DIFF
--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: staging
+          ref: main
 
       - name: Import secrets from Vault
         id: import_secrets


### PR DESCRIPTION
<!--- You can modify it as per your needs -->

### Purpose

- Avoid staging deploy bug

### Description

- Set default cd staging branch to main

### Checklist

<!-- Make sure the checkboxes reflect the actions you've taken -->

- [x] I have reviewed the code changes.
- [ ] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

<!-- Include relevant screenshots or images that help visualize the changes. -->

### Next steps

<!--- Describe further actions, if any, needed to complete the implementation  -->
