### PR TITLE
feat: add decorator to run functions only in prod

### DIFF
--- a/basedosdados_api/api/v1/tasks.py
+++ b/basedosdados_api/api/v1/tasks.py
@@ -4,6 +4,7 @@ from huey.contrib.djhuey import periodic_task
 from loguru import logger
 
 from basedosdados_api.api.v1.admin import update_table_metadata
+from basedosdados_api.utils import prod_task
 
 
 @periodic_task(crontab(minute="*/10"))
@@ -11,6 +12,7 @@ def every_ten_mins_task():
     logger.info("Am I alive between these periods?")
 
 
+@prod_task
 @periodic_task(crontab(day_of_week="0", hour="0", minute="0"))
 def update_table_metadata_task():
     update_table_metadata()

--- a/basedosdados_api/utils.py
+++ b/basedosdados_api/utils.py
@@ -47,3 +47,13 @@ def is_prod():
     if is_remote() and not is_dev() and not is_stag():
         return True
     return False
+
+
+def prod_task(func):
+    """Decorator that avoids function call if it isn't production"""
+
+    def wrapper(*args, **kwargs):
+        if is_prod():
+            return func(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
<!--- You can modify it as per your needs -->

### Purpose

- Limit tasks environments

### Description

- Add python decorator for huey tasks

### Checklist

<!-- Make sure the checkboxes reflect the actions you've taken -->

- [ ] I have reviewed the code changes.
- [ ] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

<!-- Include relevant screenshots or images that help visualize the changes. -->

### Next steps

<!--- Describe further actions, if any, needed to complete the implementation  -->
