### PR TITLE
fix: set default google group env var inside function

### DIFF
--- a/bd_api/apps/payment/webhooks.py
+++ b/bd_api/apps/payment/webhooks.py
@@ -33,12 +33,10 @@ def get_service() -> Resource:
     return build("admin", "directory_v1", credentials=credentials)
 
 
-def add_user(
-    email: str,
-    role: str = "MEMBER",
-    group_key: str = settings.GOOGLE_DIRECTORY_GROUP_KEY,
-):
+def add_user(email: str, group_key: str, role: str = "MEMBER"):
     """Add user to google group"""
+    if not group_key:
+        group_key = settings.GOOGLE_DIRECTORY_GROUP_KEY
     try:
         service = get_service()
         service.members().insert(
@@ -53,11 +51,10 @@ def add_user(
             raise e
 
 
-def remove_user(
-    email: str,
-    group_key: str = settings.GOOGLE_DIRECTORY_GROUP_KEY,
-) -> None:
+def remove_user(email: str, group_key: str) -> None:
     """Remove user from google group"""
+    if not group_key:
+        group_key = settings.GOOGLE_DIRECTORY_GROUP_KEY
     try:
         service = get_service()
         service.members().delete(


### PR DESCRIPTION
<!--- You can modify it as per your needs -->

### Purpose

- Bug

### Description

- Avoid using variable before is properly loaded

### Checklist

<!-- Make sure the checkboxes reflect the actions you've taken -->

- [ ] I have reviewed the code changes.
- [ ] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

<!-- Include relevant screenshots or images that help visualize the changes. -->

### Next steps

<!--- Describe further actions, if any, needed to complete the implementation  -->
