### PR TITLE
fix: avoid access none objects in dataset redirect

### DIFF
--- a/bd_api/apps/core/views/dataset_redirect.py
+++ b/bd_api/apps/core/views/dataset_redirect.py
@@ -7,35 +7,28 @@ from django.views import View
 from bd_api.apps.api.v1.models import CloudTable, Dataset
 
 URL_MAPPING = {
-    "localhost:8080": "localhost:3000",
-    "api.basedosdados.org": "basedosdados.org",
-    "staging.api.basedosdados.org": "staging.basedosdados.org",
-    "development.api.basedosdados.org": "development.basedosdados.org",
+    "localhost:8080": "http://localhost:3000",
+    "api.basedosdados.org": "https://basedosdados.org",
+    "staging.api.basedosdados.org": "https://staging.basedosdados.org",
+    "development.api.basedosdados.org": "https://development.basedosdados.org",
 }
 
 
 class DatasetRedirectView(View):
-    """View to redirect old dataset urls."""
+    """View to redirect old dataset urls"""
 
     def get(self, request, *args, **kwargs):
-        """Redirect to new dataset url."""
-        full_url = request.build_absolute_uri()
-        domain = urlparse(full_url).netloc
+        """Redirect to new dataset url"""
+        url = request.build_absolute_uri()
+        domain = URL_MAPPING[urlparse(url).netloc]
 
         dataset = request.GET.get("dataset")
         dataset_slug = dataset.replace("-", "_")
-        redirect_domain = URL_MAPPING[domain]
 
-        try:
-            redirect_url = CloudTable.objects.filter(gcp_dataset_id=dataset_slug).first()
-            if not redirect_url:
-                raise CloudTable.DoesNotExist
-            redirect_url = f"http://{redirect_domain}/dataset/{str(redirect_url.table.dataset.id)}"
-        except CloudTable.DoesNotExist:
-            try:
-                new_ds = Dataset.objects.filter(slug__icontains=dataset_slug).first()
-                redirect_url = f"http://{redirect_domain}/dataset/{str(new_ds.id)}"
-            except Dataset.DoesNotExist:
-                redirect_url = f"http://{redirect_domain}/404"
+        if resource := CloudTable.objects.filter(gcp_dataset_id=dataset_slug).first():
+            return HttpResponseRedirect(f"{domain}/dataset/{resource.table.dataset.id}")
 
-        return HttpResponseRedirect(redirect_url)
+        if resource := Dataset.objects.filter(slug__icontains=dataset_slug).first():
+            return HttpResponseRedirect(f"{domain}/dataset/{resource.id}")
+
+        return HttpResponseRedirect(f"{domain}/404")


### PR DESCRIPTION
<!--- You can modify it as per your needs -->

### Purpose

- Bug

### Description

- Avoid access none objects in dataset redirect

### Checklist

<!-- Make sure the checkboxes reflect the actions you've taken -->

- [ ] I have reviewed the code changes.
- [ ] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

<!-- Include relevant screenshots or images that help visualize the changes. -->

### Next steps

<!--- Describe further actions, if any, needed to complete the implementation  -->
