### PR TITLE
fix: set group_key as optional parameter

### DIFF
--- a/bd_api/apps/payment/webhooks.py
+++ b/bd_api/apps/payment/webhooks.py
@@ -33,7 +33,7 @@ def get_service() -> Resource:
     return build("admin", "directory_v1", credentials=credentials)
 
 
-def add_user(email: str, group_key: str, role: str = "MEMBER"):
+def add_user(email: str, group_key: str = None, role: str = "MEMBER"):
     """Add user to google group"""
     if not group_key:
         group_key = settings.GOOGLE_DIRECTORY_GROUP_KEY
@@ -51,7 +51,7 @@ def add_user(email: str, group_key: str, role: str = "MEMBER"):
             raise e
 
 
-def remove_user(email: str, group_key: str) -> None:
+def remove_user(email: str, group_key: str = None) -> None:
     """Remove user from google group"""
     if not group_key:
         group_key = settings.GOOGLE_DIRECTORY_GROUP_KEY


### PR DESCRIPTION
<!--- You can modify it as per your needs -->

### Purpose

- Bug

### Description

- Set `group_key` parameter of google groups functions as optional

### Checklist

<!-- Make sure the checkboxes reflect the actions you've taken -->

- [ ] I have reviewed the code changes.
- [ ] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

<!-- Include relevant screenshots or images that help visualize the changes. -->

### Next steps

<!--- Describe further actions, if any, needed to complete the implementation  -->
