### PR TITLE
fix: get stripe subscription from internal subscription

### DIFF
--- a/bd_api/apps/payment/graphql.py
+++ b/bd_api/apps/payment/graphql.py
@@ -203,7 +203,8 @@ class StripeSubscriptionDeleteMutation(Mutation):
     @login_required
     def mutate(cls, root, info, subscription_id):
         try:
-            subscription = DJStripeSubscription.objects.get(id=subscription_id)
+            subscription = Subscription.objects.get(id=subscription_id)
+            subscription = subscription.subscription
             subscription = subscription.cancel()
             return None
         except Exception as e:


### PR DESCRIPTION
<!--- You can modify it as per your needs -->

### Purpose

- Bug, fetching wrong model

### Description

- Get stripe subscription from internal subscription
  - In unsubscribe endpoint

### Checklist

<!-- Make sure the checkboxes reflect the actions you've taken -->

- [x] I have reviewed the code changes.
- [ ] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

<!-- Include relevant screenshots or images that help visualize the changes. -->

### Next steps

<!--- Describe further actions, if any, needed to complete the implementation  -->
