### PR TITLE
fix: avoid calling body after multipart request

### DIFF
--- a/bd_api/custom/graphql_jwt.py
+++ b/bd_api/custom/graphql_jwt.py
@@ -43,7 +43,7 @@ def ownership_required(f, exc=exceptions.PermissionDenied):
     """
 
     def get_uid(context, exp=r"id:\s[\"]?(\d+)[\"]?"):
-        query = context.body.decode("utf-8").replace('\\"', "")
+        query = str(context._post).replace('\\"', "")
         return [int(uid) for uid in findall(exp, query)]
 
     @wraps(f)


### PR DESCRIPTION
<!--- You can modify it as per your needs -->

### Purpose

- Enable file upload

### Description

- Avoid calling body after multipart request
  - In this case, the body is read as a byte stream **just once**

### Checklist

<!-- Make sure the checkboxes reflect the actions you've taken -->

- [x] I have reviewed the code changes.
- [ ] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

<!-- Include relevant screenshots or images that help visualize the changes. -->

### Next steps

<!--- Describe further actions, if any, needed to complete the implementation  -->
