### PR TITLE
chore: change facet quantity to 20 in dataset search

### DIFF
--- a/backend/apps/api/v1/search_views.py
+++ b/backend/apps/api/v1/search_views.py
@@ -103,7 +103,12 @@ class DatasetSearchView(FacetedSearchView):
             }
         )
 
-    def get_facets(self, sqs: SearchQuerySet):
+    def get_facets(self, sqs: SearchQuerySet, facet_size=22):
+        sqs = sqs.facet("tag_slug", size=facet_size)
+        sqs = sqs.facet("theme_slug", size=facet_size)
+        sqs = sqs.facet("entity_slug", size=facet_size)
+        sqs = sqs.facet("organization_slug", size=facet_size)
+
         facets = {}
         facet_counts = sqs.facet_counts()
         facet_counts = facet_counts.get("fields", {}).items()


### PR DESCRIPTION
### Purpose

Increase the results generated by the search function.

### Description

Currently in both production and staging environments, the metadata returned from a search has some limitations. This metadata includes themes, organizations, etc., and is capped at 10 results. As a result, users can only see a maximum of 10 themes in the sidebar. With these changes, users will be able to see more information to assist them in the search process.

### Checklist

- [x] I have reviewed the code changes.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

https://github.com/basedosdados/backend/assets/5381250/aac736f8-3220-43f1-bd12-8c381a5111d5

### Next steps

Test in the staging environment and deploy to production as soon as possible.