### PR TITLE
feat: add a new parameter to get_table_one_big_table_query

### DIFF
--- a/backend/apps/api/v1/graphql.py
+++ b/backend/apps/api/v1/graphql.py
@@ -48,11 +48,14 @@ class Query(ObjectType):
     get_table_one_big_table_query = String(
         table_id=UUID(required=True),
         columns=List(String),
+        include_table_translation=Boolean(),
     )
 
     def resolve_get_table_neighbor(root, info, table_id, **kwargs):
         return TableNeighbor.objects.filter(table_a__pk=table_id).all()
 
-    def resolve_get_table_one_big_table_query(root, info, table_id, columns=None, **kwargs):
+    def resolve_get_table_one_big_table_query(
+        root, info, table_id, columns=None, include_table_translation=True, **kwargs
+    ):
         if table := Table.objects.filter(pk=table_id).first():
-            return table.gen_one_big_table_query(columns)
+            return table.gen_one_big_table_query(columns, include_table_translation)


### PR DESCRIPTION
### Purpose

Improve the SQL queries generated in the backend.

### Description

This task simplifies the generated query to use a single, consolidated SQL table. By default, the generated SQL includes translations from the table, but it is now possible to pass a parameter that will always simplify the SQL.

### Checklist

- [x] I have reviewed the code changes.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and Evidence

The GraphQL query to be used: Pass includeTableTranslation as false to simplify the generated SQL query.

![image](https://github.com/basedosdados/backend/assets/5381250/49c8782c-73fd-498a-89e7-7402d050d09a)

This PDF represents the two versions of the query generated from the same table.
[Query_diff.pdf](https://github.com/user-attachments/files/16076184/Query_diff.pdf)



### Next Steps

Implement this in the frontend.