### PR TITLE
feat: return the sub status in the verify mutation

### DIFF
--- a/backend/custom/graphql_auto.py
+++ b/backend/custom/graphql_auto.py
@@ -39,10 +39,10 @@ from graphene_django.forms.mutation import (
 )
 from graphene_django.registry import get_global_registry
 from graphene_file_upload.scalars import Upload
-from graphql_jwt import ObtainJSONWebToken, Refresh, Verify
+from graphql_jwt import ObtainJSONWebToken, Refresh
 
 from backend.custom.graphql_base import CountableConnection, FileFieldScalar, PlainTextNode
-from backend.custom.graphql_jwt import ObtainJSONWebTokenWithUser
+from backend.custom.graphql_jwt import CustomVerify, ObtainJSONWebTokenWithUser
 from backend.custom.model import BaseModel
 
 
@@ -248,7 +248,7 @@ def build_mutation_schema(application_name: str):
         {
             "token_auth": ObtainJSONWebToken.Field(),
             "auth_token": ObtainJSONWebTokenWithUser.Field(),
-            "verify_token": Verify.Field(),
+            "verify_token": CustomVerify.Field(),
             "refresh_token": Refresh.Field(),
         }
     )


### PR DESCRIPTION
### Description

Returning the subscription status of a user when verifying the token.

### Checklist

- [x] I have reviewed the code changes.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [ ] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

![image](https://github.com/user-attachments/assets/e9b71d91-361f-4c7a-ab9e-ebf9180b68c0)
