### PR TITLE
fix: if datetime_range has a unit

### DIFF
--- a/backend/apps/api/v1/models.py
+++ b/backend/apps/api/v1/models.py
@@ -1108,7 +1108,8 @@ class Table(BaseModel, OrderedModel):
         units = []
         for coverage in self.coverages.all():
             for datetime_range in coverage.datetime_ranges.all():
-                units.append(datetime_range.unit.id)
+                if datetime_range.unit:
+                    units.append(datetime_range.unit.id)
         if not all_same(units):
             errors['datetime_range_units'] = f"Datetime range units do not refer all to the same column."
         


### PR DESCRIPTION
Contexto: @tricktx e eu tentamos mexer no conjunto `id=e9493734-a30d-4f2b-9d88-8c8a6a217ce2` e recebemos um erro de 'internal server error'. Investigando no Grafana vi que parte do log é:

```
└ <Table: mundo_bm_learning_poverty.pais> File "/app/backend/apps/api/v1/models.py", line 1111, in clean units.append(datetime_range.unit.id)
└ <django.db.models.fields.related_descriptors.ForwardManyToOneDescriptor object at 0x7d43970eb510> 
└ <DateTimeRange: 2001(0)2001>
└ <method 'append' of 'list' objects>
└ [] AttributeError: 'NoneType' object has no attribute 'id' 
```

Isso é causado por a `coverage` da tabela não ter um `datetime_range.unit` associado, pois esse campo é opcional.