### PR TITLE
fix: Handle missing unit_amount in StripePriceNode resolve_amount

### DIFF
--- a/backend/apps/account_payment/graphql.py
+++ b/backend/apps/account_payment/graphql.py
@@ -46,7 +46,9 @@ class StripePriceNode(DjangoObjectType):
         return root.djstripe_id
 
     def resolve_amount(root, info):
-        return root.unit_amount / 100
+        if root.unit_amount:
+            return root.unit_amount / 100
+        return 0
 
     def resolve_interval(root, info):
         if recurring := root.recurring:

--- a/backend/apps/account_payment/webhooks.py
+++ b/backend/apps/account_payment/webhooks.py
@@ -195,7 +195,8 @@ def setup_intent_succeeded(event: Event, **kwargs):
         customer.id, invoice_settings={"default_payment_method": setup_intent.get("payment_method")}
     )
 
-    if price_id:
+    if not customer.subscriptions and price_id:
+        logger.info(f"Add subscription to user {event.customer.email}")
         customer.subscribe(
             price=price_id,
             trial_period_days=7,


### PR DESCRIPTION
### Description

Hotfix: fix: Handle missing unit_amount in StripePriceNode resolve_amount