### PR TITLE
fix: is_required, limit choices

### DIFF
--- a/backend/apps/data_api/graphql.py
+++ b/backend/apps/data_api/graphql.py
@@ -63,8 +63,8 @@ class EndpointParameterNode(DjangoObjectType):
         filter_fields = {
             "id": ["exact"],
             "name": ["exact", "icontains"],
-            "required": ["exact"],
-            "type": ["exact"],
+            "is_required": ["exact"],
+            "type__name": ["exact"],
         }
         interfaces = (PlainTextNode,)
         connection_class = CountableConnection

--- a/backend/apps/data_api/migrations/0001_initial.py
+++ b/backend/apps/data_api/migrations/0001_initial.py
@@ -8,8 +8,6 @@ import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
 
-import backend.apps.data_api.models
-
 
 class Migration(migrations.Migration):
     initial = True
@@ -215,7 +213,6 @@ class Migration(migrations.Migration):
                     "column",
                     models.ForeignKey(
                         blank=True,
-                        limit_choices_to=backend.apps.data_api.models.limit_column_choices,
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
                         related_name="parameters",
@@ -296,7 +293,6 @@ class Migration(migrations.Migration):
             name="table",
             field=models.ForeignKey(
                 blank=True,
-                limit_choices_to=backend.apps.data_api.models.limit_table_choices,
                 null=True,
                 on_delete=django.db.models.deletion.SET_NULL,
                 related_name="endpoints",


### PR DESCRIPTION
Após testes locais onde zerei o banco e refiz todas as migrações, esses parecem ser os reparos necessários para rodar as migrações em `development`.