### PR TITLE
build: increase dev ram memory limit to 1536Mi (k8s)

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -56,7 +56,7 @@ jobs:
             resources:
               limits:
                 cpu: 500m
-                memory: 1Gi
+                memory: 1536Mi
               requests:
                 cpu: 250m
                 memory: 500Mi


### PR DESCRIPTION
# build: increase dev ram memory limit to 1536Mi

## 📝 Descrição do Pull Request

Este pull request visa aumentar o limite de memória (RAM) do pod dev no Google Kubernetes Engine (GKE) para acomodar as novas aplicações `chatbot` e `data_api`. Com a adição dessas aplicações, observou-se a necessidade de mais recursos para garantir o desempenho adequado e evitar problemas como falhas devido a consumo excessivo de memória.

