### PR TITLE
fix: mudar nome do botão Ferramentas para Importar Colunas

### DIFF
--- a/backend/templates/admin/change_form.html
+++ b/backend/templates/admin/change_form.html
@@ -4,7 +4,7 @@
 {% if opts.model_name == 'table' %}
 
 <button type="button" onclick="abrirModal()" class="btn btn-block {{ jazzmin_ui.button_classes.secondary }} btn-sm">
-    Ferramentas
+    Importar Colunas
 </button>
 
 {% endif %}
@@ -15,7 +15,7 @@
 <div id="dadosModal" class="modal" style="display: none;">
 <div class="modal-content">
     <div class="modal-header">
-        <h2>Subida De Colunas</h2>
+        <h2>Importar Colunas</h2>
         <span class="close-button">&times;</span>
     </div>
     <div class="modal-body">


### PR DESCRIPTION
# fix: mudar nome do botão Ferramentas para Importar Colunas

## 📝 Descrição do Pull Request

Renomeando botão que anteriormente se chamada "Ferramentas" para " Importar Colunas"

