### PR TITLE
feat: adding an “Importar Colunas” button

### DIFF
--- a/backend/apps/api/v1/urls.py
+++ b/backend/apps/api/v1/urls.py
@@ -5,7 +5,7 @@ from django.views.decorators.csrf import csrf_exempt
 from graphene_file_upload.django import FileUploadGraphQLView
 
 from backend.apps.api.v1.search_views import DatasetFacetValuesView, DatasetSearchView
-from backend.apps.api.v1.views import DatasetRedirectView
+from backend.apps.api.v1.views import DatasetRedirectView, upload_columns
 
 
 def redirect_to_graphql(request):
@@ -25,4 +25,5 @@ urlpatterns = [
     path("facet_values/", DatasetFacetValuesView.as_view()),
     path("dataset/", DatasetRedirectView.as_view()),
     path("dataset_redirect/", DatasetRedirectView.as_view()),
+    path("upload_columns/", upload_columns),
 ]

--- a/backend/apps/core/static/core/css/main.css
+++ b/backend/apps/core/static/core/css/main.css
@@ -4,3 +4,86 @@
     border-color: #28a745;
     box-shadow: none;
 }
+
+.botao-imagem {
+    padding: 0;
+    border: none;
+    background: none;
+    width: 150px;
+    height: 30px;
+}
+.botao-imagem img {
+    width: 150px;
+    height: 30px;
+}
+
+.modal {
+display: none;
+position: fixed;
+top: 0;
+left: 0;
+width: 100%;
+height: 100%;
+background-color: rgba(0, 0, 0, 0.5);
+z-index: 1000;
+}
+
+.modal-content {
+    background-color: white;
+    margin: 15% auto;
+    padding: 20px;
+    width: 80%;
+    max-width: 500px;
+    border-radius: 5px;
+}
+
+.form-group {
+    margin-bottom: 15px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 5px;
+}
+
+.form-group input {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+.close-button {
+    float: right;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+.loading-overlay {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0.8);
+    z-index: 1000;
+}
+
+.loading-spinner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #3498db;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: translate(-50%, -50%) rotate(0deg); }
+    100% { transform: translate(-50%, -50%) rotate(360deg); }
+}

--- a/backend/apps/core/static/core/js/ferramentas.js
+++ b/backend/apps/core/static/core/js/ferramentas.js
@@ -1,0 +1,57 @@
+const modal = document.getElementById('dadosModal');
+const closeButton = document.querySelector('.close-button');
+const dadosForm = document.getElementById('dadosForm');
+const loadingOverlay = document.getElementById('loadingOverlay');
+
+function mostrarCarregamento() {
+loadingOverlay.style.display = 'block';
+}
+
+// Função para esconder a animação de carregamento
+function esconderCarregamento() {
+loadingOverlay.style.display = 'none';
+}
+
+// Função para abrir a modal
+function abrirModal() {
+modal.style.display = 'block';
+}
+
+// Função para fechar a modal
+function fecharModal() {
+modal.style.display = 'none';
+}
+
+// Adicionar botão para abrir a modal
+// Event listeners
+closeButton.onclick = fecharModal;
+window.onclick = function(event) {
+if (event.target === modal) {
+    fecharModal();
+}
+}
+
+function processar() {
+
+const formData = new FormData(dadosForm);
+mostrarCarregamento();
+
+fetch('/upload_columns/', {
+    method: 'POST',
+    body: formData,
+    headers: {
+        'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+    }
+})
+.then(response => response.json())
+.then(data => {
+    alert('Dados enviados com sucesso!' + data);
+    fecharModal();
+})
+.catch(error => {
+    alert('Erro ao enviar dados: ' + error);
+})
+.finally(() => {
+esconderCarregamento(); // Esconde o carregamento independente do resultado
+});
+};

--- a/backend/templates/admin/change_form.html
+++ b/backend/templates/admin/change_form.html
@@ -1,0 +1,48 @@
+{% extends "admin/change_form.html" %}
+{% load static %}
+{% block extra_actions %}
+{% if opts.model_name == 'table' %}
+
+<button type="button" onclick="abrirModal()" class="btn btn-block {{ jazzmin_ui.button_classes.secondary }} btn-sm">
+    Importar Colunas
+</button>
+
+{% endif %}
+{% endblock %}
+{% block content %}
+{{ block.super }}
+{% if opts.model_name == 'table' %}
+<div id="dadosModal" class="modal" style="display: none;">
+<div class="modal-content">
+    <div class="modal-header">
+        <h2>Importar Colunas</h2>
+        <span class="close-button">&times;</span>
+    </div>
+    <div class="modal-body">
+        <form id="dadosForm">
+            {% csrf_token %}
+            <div class="form-group">
+                <label for="table_id">Table ID:</label>
+                <input type="text" id="table_id" name="table_id" required value="{{ original.pk }}" readonly>
+            </div>
+            <div class="form-group">
+                <label for="dataset_id">Dataset ID:</label>
+                <input type="text" id="dataset_id" name="dataset_id" required value="{{ original.dataset_id }}" readonly>
+            </div>
+            <div class="form-group">
+                <label for="link_arquitetura">Link Arquitetura:</label>
+                <input type="text" id="link_arquitetura" name="link_arquitetura" required>
+            </div>
+            <button type="button" class="btn btn-block {{ jazzmin_ui.button_classes.secondary }} btn-sm" onclick="processar()" class="btn">Processar</button>
+        </form>
+        <div class="loading-overlay" id="loadingOverlay">
+            <div class="loading-spinner"></div>
+        </div>
+    </div>
+</div>
+</div>
+</div>
+<script src="{% static 'core/js/ferramentas.js' %}"></script>
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
# feat: adding an “Importar Colunas” button

## Detalhes PR

Este PR adiciona um novo botão "Importar Colunas" à interface administrativa do Django, localizado na categoria Tabelas. A funcionalidade permite que os administradores importem metadados de colunas diretamente de uma arquitetura previamente definida no Google Sheets, simplificando o processo de integração e manutenção de dados.

>![image](https://github.com/user-attachments/assets/e6346595-8191-40bc-ba4f-b6835bb2ecbb)
>Botão no admin

> ![image](https://github.com/user-attachments/assets/2c2f0de4-30c5-4dbb-8349-cde8b30e7f8a)
Depois de interação com o botão
