### PR TITLE
refactor: remove `model_provider` arg

### DIFF
--- a/backend/apps/chatbot/views.py
+++ b/backend/apps/chatbot/views.py
@@ -89,11 +89,7 @@ def _get_sql_assistant():
     with PostgresSaver.from_conn_string(conn) as checkpointer:
         checkpointer.setup()
 
-        model = init_chat_model(
-            model=MODEL_URI,
-            model_provider="google_vertexai",
-            temperature=0,
-        )
+        model = init_chat_model(MODEL_URI, temperature=0)
 
         assistant = SQLAssistant(
             model=model,


### PR DESCRIPTION
This PR removes usage of the `model_provider` argument when creating the chat model instance. Instead, the model provider must now be specified directly in the `model` argument as a prefix.

Before:
```python
model = init_chat_model(
    model="gemini-2.0-flash",
    model_provider="google_vertexai",
    temperature=0,
)
```
Now:

```python
model = init_chat_model(
    model="google_vertexai:gemini-2.0-flash",
    temperature=0,
)
```