### PR TITLE
fix: dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 ARG PYTHON_VERSION=3.11-slim
 
-FROM python:${PYTHON_VERSION}
+FROM python:$PYTHON_VERSION
+
+# Defines where poetry virtual environments will be stored
+ARG POETRY_VIRTUALENVS_PATH=/opt/pypoetry/virtualenvs
 
 # Ensures that the python output is sent straight to terminal (e.g. your container log)
 # without being first buffered and that you can see the output of your application (e.g. django logs)
@@ -24,13 +27,18 @@ COPY nginx.conf /etc/nginx/nginx.conf
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.1.3
 ENV PATH="/root/.local/bin:$PATH"
 
+# Create the folder where poetry virtual environments will be stored and make it
+# accessible to all users. This is needed by the 'www-data' user during server startup
+RUN mkdir -p $POETRY_VIRTUALENVS_PATH && chmod 755 $POETRY_VIRTUALENVS_PATH
+ENV POETRY_VIRTUALENVS_PATH=$POETRY_VIRTUALENVS_PATH
+
 # Copy and install project
 WORKDIR /app
 COPY . .
 RUN test -d ./chatbot || (echo "ERROR: Git submodule 'chatbot' not found. Please run 'git submodule update --init --recursive'. See backend/README.md for more information." && exit 1)
 RUN poetry install --only main && rm nginx.conf
 
-# Copy app, generate static and set permissions
+# Generate static and set permissions
 RUN poetry run python manage.py collectstatic --no-input --settings=backend.settings.base && \
     chown -R www-data:www-data /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@ ARG PYTHON_VERSION=3.11-slim
 
 FROM python:$PYTHON_VERSION
 
-# Defines where poetry virtual environments will be stored
+# Define where Poetry virtual environments will be stored
 ARG POETRY_VIRTUALENVS_PATH=/opt/pypoetry/virtualenvs
 
-# Ensures that the python output is sent straight to terminal (e.g. your container log)
+# Ensure that the python output is sent straight to terminal (e.g. your container log)
 # without being first buffered and that you can see the output of your application (e.g. django logs)
 # in real time. Equivalent to python -u: https://docs.python.org/3/using/cmdline.html#cmdoption-u
 ENV PYTHONUNBUFFERED=1
 
-# Prevents Python from writing .pyc files to disc
+# Prevent Python from writing .pyc files to disc
 # https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDONTWRITEBYTECODE
 ENV PYTHONDONTWRITEBYTECODE=1
 
@@ -23,11 +23,12 @@ RUN apt-get update \
 RUN apt-get update && apt-get install -y postgresql postgresql-contrib
 COPY nginx.conf /etc/nginx/nginx.conf
 
-# Install Poetry and add it to PATH
+# Install Poetry and add it to PATH so its commands can be executed
+# from anywhere, without specifying the full path to its executable.
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.1.3
 ENV PATH="/root/.local/bin:$PATH"
 
-# Create the folder where poetry virtual environments will be stored and make it
+# Create the folder where Poetry virtual environments will be stored and make it
 # accessible to all users. This is needed by the 'www-data' user during server startup
 RUN mkdir -p $POETRY_VIRTUALENVS_PATH && chmod 755 $POETRY_VIRTUALENVS_PATH
 ENV POETRY_VIRTUALENVS_PATH=$POETRY_VIRTUALENVS_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,14 @@ ARG PYTHON_VERSION=3.11-slim
 
 FROM python:${PYTHON_VERSION}
 
-# Install virtualenv and create a virtual environment
-RUN pip install --no-cache-dir -U virtualenv>=20.13.1 && virtualenv /env --python=python3.11
-ENV PATH /env/bin:$PATH
+# Ensures that the python output is sent straight to terminal (e.g. your container log)
+# without being first buffered and that you can see the output of your application (e.g. django logs)
+# in real time. Equivalent to python -u: https://docs.python.org/3/using/cmdline.html#cmdoption-u
+ENV PYTHONUNBUFFERED=1
+
+# Prevents Python from writing .pyc files to disc
+# https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDONTWRITEBYTECODE
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # Install make, nginx and copy configuration
 RUN apt-get update \
@@ -15,26 +20,21 @@ RUN apt-get update \
 RUN apt-get update && apt-get install -y postgresql postgresql-contrib
 COPY nginx.conf /etc/nginx/nginx.conf
 
-# Install pip requirements
+# Install Poetry and add it to PATH
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.1.3
+ENV PATH="/root/.local/bin:$PATH"
+
+# Copy and install project
 WORKDIR /app
 COPY . .
 RUN test -d ./chatbot || (echo "ERROR: Git submodule 'chatbot' not found. Please run 'git submodule update --init --recursive'. See backend/README.md for more information." && exit 1)
-RUN /env/bin/pip install --no-cache-dir . && rm nginx.conf
-
-# Prevents Python from writing .pyc files to disc
-# https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDONTWRITEBYTECODE
-ENV PYTHONDONTWRITEBYTECODE 1
-
-# Ensures that the python output is sent straight to terminal (e.g. your container log)
-# without being first buffered and that you can see the output of your application (e.g. django logs)
-# in real time. Equivalent to python -u: https://docs.python.org/3/using/cmdline.html#cmdoption-u
-ENV PYTHONUNBUFFERED 1
+RUN poetry install --only main && rm nginx.conf
 
 # Copy app, generate static and set permissions
-RUN /env/bin/python manage.py collectstatic --no-input --settings=backend.settings.base && \
+RUN poetry run python manage.py collectstatic --no-input --settings=backend.settings.base && \
     chown -R www-data:www-data /app
 
 # Expose and run app
 EXPOSE 80
 STOPSIGNAL SIGKILL
-CMD ["/app/start-server.sh"]
+CMD ["poetry", "run", "/app/start-server.sh"]

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -50,7 +50,7 @@ services:
       dockerfile: Dockerfile
     container_name: api
     env_file: [.env.docker]
-    command: [/app/start-server-dev.sh]
+    command: [poetry, run, /app/start-server-dev.sh]
     volumes: [.:/app, $HOME/.config/pydata:$HOME/.config/pydata]
     ports:
       - 8000:8000  # Porta da api


### PR DESCRIPTION
This PR updates our `Dockerfile` to install and run the project using Poetry instead of pip. This avoids dependency resolution issues, as pip bypasses the `poetry.lock` file, potentially breaking the reproducibility that Poetr aims to provide.