### PR TITLE
chore: update `helm upgrade` command timeout to 15 minutes

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -87,6 +87,7 @@ jobs:
         run: |-
           helm upgrade \
             --wait \
+            --timeout 15m \
             --install \
             --namespace website \
             --values values.yaml \


### PR DESCRIPTION
O procedimento de deploy têm demorado mais tempo depois da atualização para utilizar o Poetry. Este PR tem como objetivo aumentar o timeout do comando `helm upgrade` para que o deploy possa completar.