### PR TITLE
chore: use gthread

### DIFF
--- a/start-server.sh
+++ b/start-server.sh
@@ -22,8 +22,7 @@ echo "> Running Gunicorn"
     --user www-data \
     --bind 0.0.0.0:8000 \
     --workers 3 \
-    --worker-class gevent \
-    --worker-connections 100 \
+    --threads 4 \
     --timeout 180
 ) &
 nginx -g "daemon off;"


### PR DESCRIPTION
Switching from `gevent` to `gthread` workers because to handle our mix of i/o and cpu heavy tasks.