### PR TITLE
fix: correct ordering by excluding null start_time runs

### DIFF
--- a/backend/apps/core/management/commands/_disable_unhealthy_flow_schedules/constants.py
+++ b/backend/apps/core/management/commands/_disable_unhealthy_flow_schedules/constants.py
@@ -29,6 +29,7 @@ class Querys(Enum):
     where: {
     flow_id: { _eq: $flow_id }
     state: { _in: ["Success", "Failed"] }
+    start_time: { _is_null: false }
     }
     order_by: { start_time: desc }
     limit: 2


### PR DESCRIPTION
# fix: correct ordering by excluding null start_time runs

## Descrição

Adiciona filtro na query GraphQL `LastTwoCompletedRunsWithTasks` para garantir que apenas `flow_runs` com `start_time` diferente de `null` sejam retornadas.

## Motivação

Evitar que execuções ainda não iniciadas (ou com `start_time` nulo) sejam consideradas na ordenação e no retorno das últimas runs finalizadas, garantindo maior consistência nos dados exibidos.

## Alteração realizada

* Inclusão do filtro:

  ```graphql
  start_time: { _is_null: false }
  ```

---
