### PR TITLE
feat: suporte a assinaturas Chatbot nos webhooks Stripe

### DIFF
--- a/backend/apps/account_payment/graphql.py
+++ b/backend/apps/account_payment/graphql.py
@@ -216,14 +216,25 @@ class StripeSubscribeMutation(Mutation):
             admin = info.context.user
             internal_subscriptions = admin.internal_subscription.all()
 
+            price = DJStripePrice.objects.get(djstripe_id=price_id)
+            new_product_code = price.product.metadata.get("code", "")
+            is_new_chatbot = "chatbot" in new_product_code.lower()
+
             for s in [
                 *admin.subscription_set.all(),
                 *internal_subscriptions,
             ]:
                 if s.is_active:
-                    return cls(errors=["Conta possui inscrição ativa"])
+                    try:
+                        existing_product_code = s.stripe_subscription
+                    except Exception:
+                        existing_product_code = ""
 
-            price = DJStripePrice.objects.get(djstripe_id=price_id)
+                    is_existing_chatbot = "chatbot" in existing_product_code.lower()
+
+                    if is_new_chatbot == is_existing_chatbot:
+                        return cls(errors=["Conta possui inscrição ativa para este tipo de plano"])
+
             is_trial_active = len(internal_subscriptions) == 0
             promotion_code = None
 

--- a/backend/apps/account_payment/webhooks.py
+++ b/backend/apps/account_payment/webhooks.py
@@ -55,6 +55,29 @@ def get_subscription(event: Event, event_context: str = None) -> Subscription:
             )
 
 
+def get_product_slug(subscription_model=None, event=None, event_context: str = None) -> str:
+    ctx = f"[{event_context}] " if event_context else ""
+    try:
+        djstripe_sub = None
+        if subscription_model and getattr(subscription_model, "subscription", None):
+            djstripe_sub = subscription_model.subscription
+        elif event:
+            sub_id = event.data.get("object", {}).get("id")
+            if sub_id:
+                djstripe_sub = DJStripeSubscription.objects.filter(id=sub_id).first()
+
+        if djstripe_sub:
+            if getattr(djstripe_sub, "plan", None) and getattr(djstripe_sub.plan, "product", None):
+                return djstripe_sub.plan.product.metadata.get("code", "")
+            elif hasattr(djstripe_sub, "items") and djstripe_sub.items.first():
+                item = djstripe_sub.items.first()
+                if getattr(item, "price", None) and getattr(item.price, "product", None):
+                    return item.price.product.metadata.get("code", "")
+    except Exception as e:
+        logger.error(f"{ctx}Erro ao recuperar product slug da assinatura: {e}")
+    return ""
+
+
 def get_credentials(scopes: list[str] = None, impersonate: str = None):
     """Get google credentials with scope or subject"""
     cred = Credentials.from_service_account_file(
@@ -260,6 +283,10 @@ def handle_subscription(event: Event):
     account = Account.objects.filter(email=event.customer.email).first()
 
     status = event.data.get("object", {}).get("status")
+    is_chatbot_plan = (
+        get_product_slug(subscription, event, event_context=event_context) == "chatbot"
+    )
+
     if status in ["trialing", "active"]:
         if subscription:
             logger.info(f"{ctx}Adicionando a inscrição do cliente {event.customer.email}")
@@ -268,11 +295,22 @@ def handle_subscription(event: Event):
 
         # Add user to google group if subscription exists or not
         if account:
-            add_user(
-                account.gcp_email or account.email, account=account, event_context=event_context
-            )
+            if is_chatbot_plan:
+                try:
+                    logger.info(
+                        f"{ctx}Liberando acesso ao chatbot para o cliente {event.customer.email}"
+                    )
+                    account.has_chatbot_access = True
+                    account.save(update_fields=["has_chatbot_access"])
+                except Exception as e:
+                    logger.error(f"{ctx}{e}")
+            else:
+                add_user(
+                    account.gcp_email or account.email, account=account, event_context=event_context
+                )
         else:
-            add_user(event.customer.email, account=None, event_context=event_context)
+            if not is_chatbot_plan:
+                add_user(event.customer.email, account=None, event_context=event_context)
     else:
         if subscription:
             logger.info(
@@ -282,13 +320,23 @@ def handle_subscription(event: Event):
             subscription.is_active = False
             subscription.save()
         # Remove user from google group if subscription exists or not
-        try:
-            if account:
-                remove_user(account.gcp_email or account.email, event_context=event_context)
-            else:
-                remove_user(event.customer.email, event_context=event_context)
-        except Exception as e:
-            logger.error(f"{ctx}{e}")
+        if is_chatbot_plan and account:
+            try:
+                logger.info(
+                    f"{ctx}Removendo acesso ao chatbot para o cliente {event.customer.email}"
+                )
+                account.has_chatbot_access = False
+                account.save(update_fields=["has_chatbot_access"])
+            except Exception as e:
+                logger.error(f"{ctx}{e}")
+        elif not is_chatbot_plan:
+            try:
+                if account:
+                    remove_user(account.gcp_email or account.email, event_context=event_context)
+                else:
+                    remove_user(event.customer.email, event_context=event_context)
+            except Exception as e:
+                logger.error(f"{ctx}{e}")
 
 
 @webhooks.handler("customer.subscription.updated")
@@ -318,14 +366,26 @@ def unsubscribe(event: Event, **kwargs):
         subscription.save()
 
     account = Account.objects.filter(email=event.customer.email).first()
-    # Remove user from google group if subscription exists or not
-    try:
-        if account:
-            remove_user(account.gcp_email or account.email, event_context=event_context)
-        else:
-            remove_user(event.customer.email, event_context=event_context)
-    except Exception as e:
-        logger.error(f"{ctx}{e}")
+    is_chatbot_plan = (
+        get_product_slug(subscription, event, event_context=event_context) == "chatbot"
+    )
+
+    if is_chatbot_plan and account:
+        try:
+            logger.info(f"{ctx}Removendo acesso ao chatbot para o cliente {event.customer.email}")
+            account.has_chatbot_access = False
+            account.save(update_fields=["has_chatbot_access"])
+        except Exception as e:
+            logger.error(f"{ctx}{e}")
+    elif not is_chatbot_plan:
+        # Remove user from google group if subscription exists or not
+        try:
+            if account:
+                remove_user(account.gcp_email or account.email, event_context=event_context)
+            else:
+                remove_user(event.customer.email, event_context=event_context)
+        except Exception as e:
+            logger.error(f"{ctx}{e}")
 
 
 @webhooks.handler("customer.subscription.paused")
@@ -344,13 +404,27 @@ def pause_subscription(event: Event, **kwargs):
         subscription.is_active = False
         subscription.save()
 
-    try:
-        if account:
-            remove_user(account.gcp_email or account.email, event_context=event_context)
-        else:
-            remove_user(event.customer.email, event_context=event_context)
-    except Exception as e:
-        logger.error(f"{ctx}{e}")
+    is_chatbot_plan = (
+        get_product_slug(subscription, event, event_context=event_context) == "chatbot"
+    )
+
+    if is_chatbot_plan and account:
+        try:
+            logger.info(
+                f"{ctx}Removendo acesso ao chatbot para o cliente {event.customer.email} (Pausado)"
+            )
+            account.has_chatbot_access = False
+            account.save(update_fields=["has_chatbot_access"])
+        except Exception as e:
+            logger.error(f"{ctx}{e}")
+    elif not is_chatbot_plan:
+        try:
+            if account:
+                remove_user(account.gcp_email or account.email, event_context=event_context)
+            else:
+                remove_user(event.customer.email, event_context=event_context)
+        except Exception as e:
+            logger.error(f"{ctx}{e}")
 
 
 @webhooks.handler("customer.subscription.resumed")
@@ -369,15 +443,29 @@ def resume_subscription(event: Event, **kwargs):
         subscription.is_active = True
         subscription.save()
 
-    try:
-        if account:
-            add_user(
-                account.gcp_email or account.email, account=account, event_context=event_context
+    is_chatbot_plan = (
+        get_product_slug(subscription, event, event_context=event_context) == "chatbot"
+    )
+
+    if is_chatbot_plan and account:
+        try:
+            logger.info(
+                f"{ctx}Liberando acesso ao chatbot para o cliente {event.customer.email} (Resumido)"
             )
-        else:
-            add_user(event.customer.email, account=None, event_context=event_context)
-    except Exception as e:
-        logger.error(f"{ctx}{e}")
+            account.has_chatbot_access = True
+            account.save(update_fields=["has_chatbot_access"])
+        except Exception as e:
+            logger.error(f"{ctx}{e}")
+    elif not is_chatbot_plan:
+        try:
+            if account:
+                add_user(
+                    account.gcp_email or account.email, account=account, event_context=event_context
+                )
+            else:
+                add_user(event.customer.email, account=None, event_context=event_context)
+        except Exception as e:
+            logger.error(f"{ctx}{e}")
 
 
 @webhooks.handler("setup_intent.succeeded")


### PR DESCRIPTION
O sistema de pagamento tratava todos os planos Stripe da mesma forma, sem distinguir entre BDPro e Chatbot. Isso impedia que um usuário tivesse assinaturas ativas de tipos diferentes e gerava comportamentos incorretos nos webhooks — como tentar remover um usuário do Google Group ao cancelar um plano Chatbot.

## Principais mudanças

**1. Nova função `get_product_slug` em `webhooks.py`**

Extrai o slug do produto (`code`) a partir dos metadados da assinatura Stripe, consultando tanto `subscription.plan.product` quanto `subscription.items` como fallback. Retorna string vazia em caso de erro.

```python
def get_product_slug(subscription_model=None, event=None, event_context: str = None) -> str:
    ...
    return djstripe_sub.plan.product.metadata.get("code", "")
```

**2. Webhooks diferenciam plano BDPro de Chatbot**

Os handlers `handle_subscription`, `unsubscribe`, `pause_subscription` e `resume_subscription` agora verificam `is_chatbot_plan` antes de agir:

- **Chatbot ativo/retomado** → seta `account.has_chatbot_access = True`
- **Chatbot cancelado/pausado** → seta `account.has_chatbot_access = False`
- **BDPro** → comportamento anterior (add/remove do Google Group)

**3. Múltiplas assinaturas ativas de tipos diferentes**

A mutation `CreateSubscription` em `graphql.py` agora permite que um usuário tenha uma assinatura BDPro e uma Chatbot simultaneamente. O bloqueio só ocorre se já existir uma assinatura ativa **do mesmo tipo**:

```python
if is_new_chatbot == is_existing_chatbot:
    return cls(errors=["Conta possui inscrição ativa para este tipo de plano"])
```
