### PR TITLE
feat: refatora webhooks do Stripe para separar entitlements de chatbot e bd_pro

### DIFF
--- a/backend/apps/account_payment/webhooks.py
+++ b/backend/apps/account_payment/webhooks.py
@@ -7,13 +7,13 @@ from django.conf import settings
 from django.db.models import Q
 from djstripe import webhooks
 from djstripe.models import Event
+from djstripe.models import Price as DJStripePrice
 from djstripe.models import Subscription as DJStripeSubscription
 from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import Resource, build
 from googleapiclient.errors import HttpError
 from loguru import logger
 from stripe import Customer as StripeCustomer
-from stripe import Subscription as StripeSubscription
 
 from backend.apps.account.models import Account, Subscription
 from backend.custom.client import send_discord_message as send
@@ -155,6 +155,34 @@ def _account_has_other_active_chatbot_subscription(
     return any(_djstripe_subscription_is_chatbot(s) for s in qs.iterator(chunk_size=20))
 
 
+def _account_has_active_non_chatbot_subscription(account: Account) -> bool:
+    qs = DJStripeSubscription.objects.filter(
+        customer__subscriber=account,
+        status__in=["active", "trialing"],
+    )
+    return any(not _djstripe_subscription_is_chatbot(s) for s in qs.iterator(chunk_size=20))
+
+
+def _price_is_chatbot(price_id: str) -> bool | None:
+    price = (
+        DJStripePrice.objects.filter(id=price_id).first()
+        or DJStripePrice.objects.filter(djstripe_id=price_id).first()
+    )
+    if not price or not getattr(price, "product", None):
+        return None
+    return "chatbot" in price.product.metadata.get("code", "").lower()
+
+
+def _customer_has_active_subscription_of_type(customer, is_chatbot: bool) -> bool:
+    qs = DJStripeSubscription.objects.filter(
+        customer=customer,
+        status__in=["active", "trialing"],
+    )
+    return any(
+        _djstripe_subscription_is_chatbot(s) == is_chatbot for s in qs.iterator(chunk_size=20)
+    )
+
+
 def _set_account_chatbot_access(
     account: Account,
     enabled: bool,
@@ -264,12 +292,9 @@ def remove_user(email: str, group_key: str = None, event_context: str = None) ->
             logger.warning(f"{ctx}Bloqueado: {raw_email} é admin. Não removido do Google Groups.")
             return
 
-        has_active_sub = (
-            getattr(user, "is_subscriber", False)
-            or DJStripeSubscription.objects.filter(
-                customer__subscriber=user, status__in=["active", "trialing"]
-            ).exists()
-        )
+        has_active_sub = getattr(
+            user, "is_subscriber", False
+        ) or _account_has_active_non_chatbot_subscription(user)
 
         if has_active_sub:
             logger.warning(
@@ -586,17 +611,28 @@ def setup_intent_succeeded(event: Event, **kwargs):
             invoice_settings={"default_payment_method": payment_method},
         )
 
-    subscriptions = StripeSubscription.list(customer=customer.id)
-    has_subscription = len(subscriptions.get("data", [])) > 0
+    if not price_id:
+        return
+
+    is_chatbot_price = _price_is_chatbot(price_id)
+    if is_chatbot_price is None:
+        logger.warning(f"{ctx}Price {price_id!r} não encontrado; assinatura não criada.")
+        return
+
+    if _customer_has_active_subscription_of_type(customer, is_chatbot_price):
+        product_label = "chatbot" if is_chatbot_price else "bd_pro"
+        return logger.info(
+            f"{ctx}Cliente {event.customer.email} já possui assinatura ativa/trial "
+            f"do tipo {product_label}; assinatura não criada."
+        )
 
     if promotion_code:
         discounts = [{"promotion_code": promotion_code}]
     else:
         discounts = []
 
-    if not has_subscription and price_id:
-        logger.info(f"{ctx}Add subscription to user {event.customer.email}")
-        customer.subscribe(price=price_id, trial_period_days=7, discounts=discounts)
+    logger.info(f"{ctx}Add subscription to user {event.customer.email}")
+    customer.subscribe(price=price_id, trial_period_days=7, discounts=discounts)
 
 
 # Reference

--- a/backend/apps/account_payment/webhooks.py
+++ b/backend/apps/account_payment/webhooks.py
@@ -23,7 +23,18 @@ logger = logger.bind(module="payment")
 
 
 def _normalize_plus(email: str) -> str:
-    """Normalize: trim, lower and remove +alias before @."""
+    """Normalize an email address for comparison and lookup.
+
+    Trims whitespace, lowercases the address, and strips a `+alias` suffix
+    from the local part (e.g. `user+test@example.com` -> `user@example.com`)
+    so addresses with plus-aliasing still match the canonical account email.
+
+    Args:
+        email: Raw email address to normalize.
+
+    Returns:
+        The normalized email address.
+    """
     email = email.strip().lower()
     local, _, domain = email.partition("@")
     if "+" in local:
@@ -32,7 +43,22 @@ def _normalize_plus(email: str) -> str:
 
 
 def get_subscription(event: Event, event_context: str = None) -> Subscription | None:
-    """Get internal subscription model, mirror of stripe"""
+    """Get (or lazily create) the internal Subscription mirroring a Stripe event.
+
+    Looks up the DJStripeSubscription referenced by the event, then returns
+    the internal `Subscription` model that mirrors it, creating it on first
+    use if the Stripe customer has a known subscriber account.
+
+    Args:
+        event: Stripe webhook event whose `data.object.id` identifies the
+            underlying Stripe subscription.
+        event_context: Human-readable context prefixed to log messages.
+
+    Returns:
+        The internal `Subscription` instance, or `None` if the event has no
+        subscription id, the DJStripeSubscription doesn't exist yet, or the
+        Stripe customer has no associated subscriber account.
+    """
     ctx = f"[{event_context}] " if event_context else ""
     subscription_id = event.data.get("object", {}).get("id")
     if not subscription_id:
@@ -60,6 +86,24 @@ def get_subscription(event: Event, event_context: str = None) -> Subscription | 
 
 
 def get_product_slug(subscription_model=None, event=None, event_context: str = None) -> str:
+    """Resolve the Stripe product `code` metadata for a subscription.
+
+    Walks from an internal `Subscription` (or, failing that, from the
+    event's underlying DJStripeSubscription) through its plan/price to the
+    Stripe Product, returning the `code` value from the product's metadata.
+    Used to distinguish products (e.g. "chatbot" vs "bd_pro") for
+    entitlement routing.
+
+    Args:
+        subscription_model: Internal `Subscription` instance to resolve the
+            product from, if available.
+        event: Stripe webhook event to fall back to when `subscription_model`
+            has no linked DJStripeSubscription.
+        event_context: Human-readable context prefixed to log messages.
+
+    Returns:
+        The product's `code` metadata value, or `""` if it can't be resolved.
+    """
     ctx = f"[{event_context}] " if event_context else ""
     try:
         djstripe_sub = None
@@ -83,7 +127,18 @@ def get_product_slug(subscription_model=None, event=None, event_context: str = N
 
 
 class WebhookContext(NamedTuple):
-    """Common context validated once per Stripe event (customer + email + log strings)."""
+    """Common context validated once per Stripe event.
+
+    Bundles the event, a human-readable description, the formatted log
+    prefix, and the customer's email so handlers don't need to re-derive or
+    re-validate them.
+
+    Attributes:
+        event: The Stripe webhook event being processed.
+        event_context: Human-readable description of the event (type + id).
+        ctx: `event_context` formatted as a log-line prefix, e.g. `"[...] "`.
+        customer_email: The Stripe customer's email address.
+    """
 
     event: Event
     event_context: str
@@ -96,9 +151,20 @@ def require_webhook_customer_context(
     *,
     log_if_invalid: bool = False,
 ) -> WebhookContext | None:
-    """
-    Ensures the event has a Stripe customer with an email.
-    Centralizes the repeated validation in the handlers and avoids scattered checks.
+    """Validate that an event has a Stripe customer with an email.
+
+    Centralizes the customer/email guard that every subscription handler
+    needs before doing any work, and builds the shared `WebhookContext` used
+    for logging and entitlement routing.
+
+    Args:
+        event: The Stripe webhook event to validate.
+        log_if_invalid: Whether to emit a warning log when the customer or
+            email is missing.
+
+    Returns:
+        A populated `WebhookContext`, or `None` if the event has no customer
+        or the customer has no email.
     """
     customer = getattr(event, "customer", None)
     email = getattr(customer, "email", None) if customer else None
@@ -117,6 +183,15 @@ def require_webhook_customer_context(
 
 
 def get_account_for_stripe_customer(event: Event) -> Account | None:
+    """Look up the internal Account matching an event's Stripe customer.
+
+    Args:
+        event: Stripe webhook event whose `customer.email` identifies the
+            account.
+
+    Returns:
+        The matching `Account`, or `None` if no account has that email.
+    """
     return Account.objects.filter(email=event.customer.email).first()
 
 
@@ -125,10 +200,33 @@ def subscription_product_is_chatbot(
     event: Event,
     event_context: str,
 ) -> bool:
+    """Check whether a subscription's product is the chatbot product.
+
+    Args:
+        subscription: Internal `Subscription` instance, if available.
+        event: Stripe webhook event to fall back to for product resolution.
+        event_context: Human-readable context prefixed to log messages.
+
+    Returns:
+        `True` if the resolved product slug is exactly `"chatbot"`.
+    """
     return get_product_slug(subscription, event, event_context=event_context) == "chatbot"
 
 
 def _djstripe_subscription_is_chatbot(dj_sub: DJStripeSubscription) -> bool:
+    """Check whether a DJStripeSubscription's product is the chatbot product.
+
+    Walks the subscription's plan/price to the Stripe Product metadata,
+    mirroring `get_product_slug`'s traversal but operating directly on a
+    `DJStripeSubscription` instance instead of an event or internal model.
+
+    Args:
+        dj_sub: The dj-stripe `Subscription` instance to inspect.
+
+    Returns:
+        `True` if the product's `code` metadata is exactly `"chatbot"`.
+        `False` if it can't be resolved or any lookup raises.
+    """
     try:
         if getattr(dj_sub, "plan", None) and getattr(dj_sub.plan, "product", None):
             return dj_sub.plan.product.metadata.get("code", "") == "chatbot"
@@ -145,7 +243,21 @@ def _account_has_other_active_chatbot_subscription(
     account: Account,
     exclude_stripe_subscription_id: str | None,
 ) -> bool:
-    """True if the customer still has another active/trialing Stripe sub for the chatbot product."""
+    """Check if an account has another active/trialing chatbot subscription.
+
+    Used when revoking chatbot access, to avoid removing it if the customer
+    still has a second active or trialing chatbot subscription (e.g. after
+    switching plans).
+
+    Args:
+        account: The account whose Stripe subscriptions to check.
+        exclude_stripe_subscription_id: Stripe subscription id to exclude
+            from the check (typically the one the current event is about).
+
+    Returns:
+        `True` if at least one other active/trialing chatbot subscription
+        exists for the account's Stripe customer.
+    """
     qs = DJStripeSubscription.objects.filter(
         customer__subscriber=account,
         status__in=["active", "trialing"],
@@ -156,6 +268,20 @@ def _account_has_other_active_chatbot_subscription(
 
 
 def _account_has_active_non_chatbot_subscription(account: Account) -> bool:
+    """Check if an account has an active/trialing non-chatbot subscription.
+
+    Used by `remove_user` to decide whether an account should keep its
+    Google Group membership: chatbot subscriptions don't grant Google Group
+    access, so only non-chatbot (e.g. bd_pro) subscriptions should block
+    removal.
+
+    Args:
+        account: The account whose Stripe subscriptions to check.
+
+    Returns:
+        `True` if at least one active/trialing non-chatbot subscription
+        exists for the account's Stripe customer.
+    """
     qs = DJStripeSubscription.objects.filter(
         customer__subscriber=account,
         status__in=["active", "trialing"],
@@ -164,6 +290,17 @@ def _account_has_active_non_chatbot_subscription(account: Account) -> bool:
 
 
 def _price_is_chatbot(price_id: str) -> bool | None:
+    """Check whether a Stripe Price belongs to the chatbot product.
+
+    Args:
+        price_id: Stripe price id (or dj-stripe internal id, as a fallback)
+            to look up.
+
+    Returns:
+        `True`/`False` depending on whether the price's product `code`
+        metadata contains `"chatbot"`, or `None` if the price (or its
+        product) can't be found.
+    """
     price = (
         DJStripePrice.objects.filter(id=price_id).first()
         or DJStripePrice.objects.filter(djstripe_id=price_id).first()
@@ -174,6 +311,21 @@ def _price_is_chatbot(price_id: str) -> bool | None:
 
 
 def _customer_has_active_subscription_of_type(customer, is_chatbot: bool) -> bool:
+    """Check if a Stripe customer already has an active sub of a given type.
+
+    Used by `setup_intent_succeeded` to avoid creating a duplicate
+    subscription for the same product type (chatbot or bd_pro) while still
+    allowing the customer to hold one of each.
+
+    Args:
+        customer: The dj-stripe `Customer` instance to check.
+        is_chatbot: Whether to match chatbot subscriptions (`True`) or
+            non-chatbot subscriptions (`False`).
+
+    Returns:
+        `True` if an active/trialing subscription of the requested type
+        already exists for the customer.
+    """
     qs = DJStripeSubscription.objects.filter(
         customer=customer,
         status__in=["active", "trialing"],
@@ -189,6 +341,17 @@ def _set_account_chatbot_access(
     wc: WebhookContext,
     log_message: str,
 ) -> None:
+    """Grant or revoke an account's chatbot access, protecting admins.
+
+    Admin accounts are never automatically stripped of chatbot access by a
+    webhook; a revocation attempt for an admin is logged and skipped.
+
+    Args:
+        account: The account to update.
+        enabled: `True` to grant chatbot access, `False` to revoke it.
+        wc: Context for the originating webhook event, used for logging.
+        log_message: Message to log when the change is applied.
+    """
     try:
         if not enabled and account.is_admin:
             logger.warning(
@@ -203,7 +366,16 @@ def _set_account_chatbot_access(
 
 
 def get_credentials(scopes: list[str] = None, impersonate: str = None):
-    """Get google credentials with scope or subject"""
+    """Build Google service-account credentials.
+
+    Args:
+        scopes: OAuth scopes to request, if any.
+        impersonate: Subject (user email) to impersonate via domain-wide
+            delegation, if any.
+
+    Returns:
+        A `google.oauth2.service_account.Credentials` instance.
+    """
     cred = Credentials.from_service_account_file(
         settings.GOOGLE_APPLICATION_CREDENTIALS,
     )
@@ -215,7 +387,12 @@ def get_credentials(scopes: list[str] = None, impersonate: str = None):
 
 
 def get_service() -> Resource:
-    """Get google directory service"""
+    """Build an authenticated Google Workspace Directory API client.
+
+    Returns:
+        A `Resource` for the `admin` `directory_v1` API, scoped and
+        impersonating the subject configured in settings.
+    """
     credentials = get_credentials(
         settings.GOOGLE_DIRECTORY_SCOPES,
         settings.GOOGLE_DIRECTORY_SUBJECT,
@@ -230,7 +407,25 @@ def add_user(
     role: str = "MEMBER",
     event_context: str = None,
 ):
-    """Add user to google group"""
+    """Add a user to the Google Group used to gate BD Pro access.
+
+    In dev/staging environments, only admin accounts are actually added, to
+    avoid polluting the real Google Group from test events.
+
+    Args:
+        email: Email address to add to the group; normalized before use.
+        account: Account associated with `email`, if already known. If not
+            given, it's looked up by `email` (with +alias normalization)
+            when running in dev/staging.
+        group_key: Google Group key to add the member to. Defaults to
+            `settings.GOOGLE_DIRECTORY_GROUP_KEY`.
+        role: Google Group member role to assign.
+        event_context: Human-readable context prefixed to log messages.
+
+    Raises:
+        HttpError: If the Google API call fails for a reason other than the
+            member already existing (HTTP 409).
+    """
     ctx = f"[{event_context}] " if event_context else ""
     if is_dev() or is_stg():
         if account is None:
@@ -265,7 +460,25 @@ def add_user(
 
 
 def remove_user(email: str, group_key: str = None, event_context: str = None) -> None:
-    """Remove user from Google Group"""
+    """Remove a user from the Google Group used to gate BD Pro access.
+
+    Refuses to remove admin accounts, and refuses to remove any account that
+    still has an active subscriber flag or an active non-chatbot
+    subscription (chatbot subscriptions don't grant Google Group access, so
+    they don't block removal here).
+
+    Args:
+        email: Email address to remove; matched against the account's email
+            or gcp_email (raw and +alias-normalized).
+        group_key: Google Group key to remove the member from. Defaults to
+            `settings.GOOGLE_DIRECTORY_GROUP_KEY`.
+        event_context: Human-readable context prefixed to log messages.
+
+    Raises:
+        HttpError: If the Google API call fails for a reason other than the
+            member not being found (HTTP 404/400).
+        Exception: Any other unexpected error during removal.
+    """
     ctx = f"[{event_context}] " if event_context else ""
     if not email or "@" not in email:
         logger.error(f"{ctx}E-mail inválido fornecido: {email!r}")
@@ -338,9 +551,22 @@ def apply_active_subscription_entitlements(
     *,
     chatbot_grant_message: str | None = None,
 ) -> None:
-    """
-    Active/trial/resumed subscription: grants chatbot access or adds to
-    Google Group according to the product.
+    """Grant entitlements for an active, trialing, or resumed subscription.
+
+    Routes the grant based on the subscription's product: chatbot
+    subscriptions set `account.has_chatbot_access`, other products add the
+    customer to the Google Group. If there's no matching internal account
+    and the product isn't chatbot, the Google Group is granted by email
+    alone.
+
+    Args:
+        wc: Context for the originating webhook event.
+        subscription: Internal `Subscription` instance, used to resolve the
+            product type.
+        account: Account to grant entitlements to, if one exists for the
+            Stripe customer.
+        chatbot_grant_message: Log message to use when granting chatbot
+            access. Defaults to a generic "Liberando acesso..." message.
     """
     is_chat = subscription_product_is_chatbot(subscription, wc.event, wc.event_context)
     grant_msg = (
@@ -376,9 +602,21 @@ def apply_inactive_subscription_entitlements(
     *,
     chatbot_revoke_message: str | None = None,
 ) -> None:
-    """
-    Inactive/deleted/paused subscription: revokes chatbot access or removes from
-    Google Group according to the product.
+    """Revoke entitlements for an inactive, deleted, or paused subscription.
+
+    Routes the revocation based on the subscription's product: for chatbot
+    subscriptions, access is only revoked if the account has no other
+    active/trialing chatbot subscription; for other products, the customer
+    is removed from the Google Group.
+
+    Args:
+        wc: Context for the originating webhook event.
+        subscription: Internal `Subscription` instance, used to resolve the
+            product type.
+        account: Account to revoke entitlements from, if one exists for the
+            Stripe customer.
+        chatbot_revoke_message: Log message to use when revoking chatbot
+            access. Defaults to a generic "Removendo acesso..." message.
     """
     is_chat = subscription_product_is_chatbot(subscription, wc.event, wc.event_context)
     revoke_msg = (
@@ -408,7 +646,18 @@ def apply_inactive_subscription_entitlements(
 
 
 def list_user(group_key: str = None):
-    """List users from google group"""
+    """List members of a Google Group.
+
+    Args:
+        group_key: Google Group key to list. Defaults to
+            `settings.GOOGLE_DIRECTORY_GROUP_KEY`.
+
+    Returns:
+        The Google Directory API response listing the group's members.
+
+    Raises:
+        Exception: If the Google API call fails.
+    """
     if not group_key:
         group_key = settings.GOOGLE_DIRECTORY_GROUP_KEY
     try:
@@ -420,7 +669,20 @@ def list_user(group_key: str = None):
 
 
 def is_email_in_group(email: str, group_key: str = None) -> bool:
-    """Check if a user is in a Google group."""
+    """Check whether an email address is a member of a Google Group.
+
+    Args:
+        email: Email address to check; normalized before lookup.
+        group_key: Google Group key to check. Defaults to
+            `settings.GOOGLE_DIRECTORY_GROUP_KEY`.
+
+    Returns:
+        `True` if the email is a member of the group. `False` if it isn't a
+        member or the lookup fails with an HTTP error.
+
+    Raises:
+        Exception: If an unexpected (non-HTTP) error occurs during lookup.
+    """
     if not group_key:
         group_key = settings.GOOGLE_DIRECTORY_GROUP_KEY
 
@@ -452,7 +714,13 @@ def is_email_in_group(email: str, group_key: str = None) -> bool:
 
 @webhooks.handler("customer.updated")
 def update_customer(event: Event, **kwargs):
-    """Propagate customer email update if exists"""
+    """Propagate a Stripe customer's email change to the internal Account.
+
+    Args:
+        event: The `customer.updated` Stripe webhook event.
+        **kwargs: Unused; accepted for compatibility with the djstripe
+            webhook handler signature.
+    """
     if not getattr(event, "customer", None):
         return
 
@@ -468,7 +736,20 @@ def update_customer(event: Event, **kwargs):
 
 
 def handle_subscription(event: Event):
-    """Handle subscription status"""
+    """Sync the internal Subscription and entitlements for a status change.
+
+    Shared by `subscription_updated` and `subscribe`. Updates the internal
+    `Subscription.is_active` flag to match the Stripe subscription status,
+    then grants or revokes entitlements accordingly:
+
+    - `trialing`/`active`: grants entitlements.
+    - `incomplete`: checkout still in progress; only the internal record is
+      updated, entitlements are left untouched.
+    - any other status: revokes entitlements.
+
+    Args:
+        event: The Stripe subscription webhook event to handle.
+    """
     wc = require_webhook_customer_context(event, log_if_invalid=True)
     if not wc:
         return
@@ -508,19 +789,37 @@ def handle_subscription(event: Event):
 
 @webhooks.handler("customer.subscription.updated")
 def subscription_updated(event: Event, **kwargs):
-    """Handle subscription status update"""
+    """Handle a Stripe subscription status update.
+
+    Args:
+        event: The `customer.subscription.updated` Stripe webhook event.
+        **kwargs: Unused; accepted for compatibility with the djstripe
+            webhook handler signature.
+    """
     handle_subscription(event)
 
 
 @webhooks.handler("customer.subscription.created")
 def subscribe(event: Event, **kwargs):
-    """Add customer to allowed google groups"""
+    """Grant entitlements for a newly created Stripe subscription.
+
+    Args:
+        event: The `customer.subscription.created` Stripe webhook event.
+        **kwargs: Unused; accepted for compatibility with the djstripe
+            webhook handler signature.
+    """
     handle_subscription(event)
 
 
 @webhooks.handler("customer.subscription.deleted")
 def unsubscribe(event: Event, **kwargs):
-    """Remove customer from allowed google groups"""
+    """Revoke entitlements for a deleted Stripe subscription.
+
+    Args:
+        event: The `customer.subscription.deleted` Stripe webhook event.
+        **kwargs: Unused; accepted for compatibility with the djstripe
+            webhook handler signature.
+    """
     wc = require_webhook_customer_context(event, log_if_invalid=False)
     if not wc:
         return
@@ -537,7 +836,13 @@ def unsubscribe(event: Event, **kwargs):
 
 @webhooks.handler("customer.subscription.paused")
 def pause_subscription(event: Event, **kwargs):
-    """Pause customer subscription"""
+    """Revoke entitlements for a paused Stripe subscription.
+
+    Args:
+        event: The `customer.subscription.paused` Stripe webhook event.
+        **kwargs: Unused; accepted for compatibility with the djstripe
+            webhook handler signature.
+    """
     wc = require_webhook_customer_context(event, log_if_invalid=False)
     if not wc:
         return
@@ -562,7 +867,13 @@ def pause_subscription(event: Event, **kwargs):
 
 @webhooks.handler("customer.subscription.resumed")
 def resume_subscription(event: Event, **kwargs):
-    """Resume customer subscription"""
+    """Grant entitlements for a resumed Stripe subscription.
+
+    Args:
+        event: The `customer.subscription.resumed` Stripe webhook event.
+        **kwargs: Unused; accepted for compatibility with the djstripe
+            webhook handler signature.
+    """
     wc = require_webhook_customer_context(event, log_if_invalid=False)
     if not wc:
         return
@@ -587,7 +898,24 @@ def resume_subscription(event: Event, **kwargs):
 
 @webhooks.handler("setup_intent.succeeded")
 def setup_intent_succeeded(event: Event, **kwargs):
-    """Update customer default payment method and subscribe to plan with trial"""
+    """Finish checkout: save the payment method and start the subscription.
+
+    Triggered after a customer confirms a SetupIntent during checkout. Sets
+    the confirmed payment method as the customer's default, then creates a
+    trialing subscription for the price encoded in the SetupIntent's
+    metadata — unless the customer already has an active/trialing
+    subscription of the same product type (chatbot or bd_pro), in which
+    case no new subscription is created.
+
+    Ignores SetupIntents whose `backend_url` metadata doesn't match this
+    backend's URL (e.g. events from another environment sharing the same
+    Stripe account).
+
+    Args:
+        event: The `setup_intent.succeeded` Stripe webhook event.
+        **kwargs: Unused; accepted for compatibility with the djstripe
+            webhook handler signature.
+    """
     if not getattr(event, "customer", None):
         return
 

--- a/backend/apps/account_payment/webhooks.py
+++ b/backend/apps/account_payment/webhooks.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import NamedTuple
+
 from django.conf import settings
 from django.db.models import Q
 from djstripe import webhooks
@@ -19,7 +23,7 @@ logger = logger.bind(module="payment")
 
 
 def _normalize_plus(email: str) -> str:
-    """Normaliza: trim, lower e remove +alias antes do @."""
+    """Normalize: trim, lower and remove +alias before @."""
     email = email.strip().lower()
     local, _, domain = email.partition("@")
     if "+" in local:
@@ -27,7 +31,7 @@ def _normalize_plus(email: str) -> str:
     return f"{local}@{domain}"
 
 
-def get_subscription(event: Event, event_context: str = None) -> Subscription:
+def get_subscription(event: Event, event_context: str = None) -> Subscription | None:
     """Get internal subscription model, mirror of stripe"""
     ctx = f"[{event_context}] " if event_context else ""
     subscription_id = event.data.get("object", {}).get("id")
@@ -76,6 +80,98 @@ def get_product_slug(subscription_model=None, event=None, event_context: str = N
     except Exception as e:
         logger.error(f"{ctx}Erro ao recuperar product slug da assinatura: {e}")
     return ""
+
+
+class WebhookContext(NamedTuple):
+    """Common context validated once per Stripe event (customer + email + log strings)."""
+
+    event: Event
+    event_context: str
+    ctx: str
+    customer_email: str
+
+
+def require_webhook_customer_context(
+    event: Event,
+    *,
+    log_if_invalid: bool = False,
+) -> WebhookContext | None:
+    """
+    Ensures the event has a Stripe customer with an email.
+    Centralizes the repeated validation in the handlers and avoids scattered checks.
+    """
+    customer = getattr(event, "customer", None)
+    email = getattr(customer, "email", None) if customer else None
+    if not customer or not email:
+        if log_if_invalid:
+            logger.warning(f"Webhook {event.type} abortado: cliente ou e-mail ausente.")
+        return None
+    event_context = f"Webhook: {event.type} | Event ID: {event.id}"
+    ctx = f"[{event_context}] "
+    return WebhookContext(
+        event=event,
+        event_context=event_context,
+        ctx=ctx,
+        customer_email=email,
+    )
+
+
+def get_account_for_stripe_customer(event: Event) -> Account | None:
+    return Account.objects.filter(email=event.customer.email).first()
+
+
+def subscription_product_is_chatbot(
+    subscription: Subscription | None,
+    event: Event,
+    event_context: str,
+) -> bool:
+    return get_product_slug(subscription, event, event_context=event_context) == "chatbot"
+
+
+def _djstripe_subscription_is_chatbot(dj_sub: DJStripeSubscription) -> bool:
+    try:
+        if getattr(dj_sub, "plan", None) and getattr(dj_sub.plan, "product", None):
+            return dj_sub.plan.product.metadata.get("code", "") == "chatbot"
+        if hasattr(dj_sub, "items") and dj_sub.items.first():
+            item = dj_sub.items.first()
+            if getattr(item, "price", None) and getattr(item.price, "product", None):
+                return item.price.product.metadata.get("code", "") == "chatbot"
+    except Exception:
+        pass
+    return False
+
+
+def _account_has_other_active_chatbot_subscription(
+    account: Account,
+    exclude_stripe_subscription_id: str | None,
+) -> bool:
+    """True if the customer still has another active/trialing Stripe sub for the chatbot product."""
+    qs = DJStripeSubscription.objects.filter(
+        customer__subscriber=account,
+        status__in=["active", "trialing"],
+    )
+    if exclude_stripe_subscription_id:
+        qs = qs.exclude(id=exclude_stripe_subscription_id)
+    return any(_djstripe_subscription_is_chatbot(s) for s in qs.iterator(chunk_size=20))
+
+
+def _set_account_chatbot_access(
+    account: Account,
+    enabled: bool,
+    wc: WebhookContext,
+    log_message: str,
+) -> None:
+    try:
+        if not enabled and account.is_admin:
+            logger.warning(
+                f"{wc.ctx}Bloqueado: {account.email} é admin. Acesso ao chatbot não removido."
+            )
+            return
+        logger.info(f"{wc.ctx}{log_message}")
+        account.has_chatbot_access = enabled
+        account.save(update_fields=["has_chatbot_access"])
+    except Exception as e:
+        logger.error(f"{wc.ctx}{e}")
 
 
 def get_credentials(scopes: list[str] = None, impersonate: str = None):
@@ -210,6 +306,82 @@ def remove_user(email: str, group_key: str = None, event_context: str = None) ->
         raise
 
 
+def apply_active_subscription_entitlements(
+    wc: WebhookContext,
+    subscription: Subscription | None,
+    account: Account | None,
+    *,
+    chatbot_grant_message: str | None = None,
+) -> None:
+    """
+    Active/trial/resumed subscription: grants chatbot access or adds to
+    Google Group according to the product.
+    """
+    is_chat = subscription_product_is_chatbot(subscription, wc.event, wc.event_context)
+    grant_msg = (
+        chatbot_grant_message or f"Liberando acesso ao chatbot para o cliente {wc.customer_email}"
+    )
+    if account:
+        if is_chat:
+            _set_account_chatbot_access(account, True, wc, grant_msg)
+        else:
+            try:
+                add_user(
+                    account.gcp_email or account.email,
+                    account=account,
+                    event_context=wc.event_context,
+                )
+            except Exception as e:
+                logger.error(f"{wc.ctx}{e}")
+    elif not is_chat:
+        try:
+            add_user(
+                wc.customer_email,
+                account=None,
+                event_context=wc.event_context,
+            )
+        except Exception as e:
+            logger.error(f"{wc.ctx}{e}")
+
+
+def apply_inactive_subscription_entitlements(
+    wc: WebhookContext,
+    subscription: Subscription | None,
+    account: Account | None,
+    *,
+    chatbot_revoke_message: str | None = None,
+) -> None:
+    """
+    Inactive/deleted/paused subscription: revokes chatbot access or removes from
+    Google Group according to the product.
+    """
+    is_chat = subscription_product_is_chatbot(subscription, wc.event, wc.event_context)
+    revoke_msg = (
+        chatbot_revoke_message or f"Removendo acesso ao chatbot para o cliente {wc.customer_email}"
+    )
+    if is_chat and account:
+        ev_sub_id = wc.event.data.get("object", {}).get("id")
+        if _account_has_other_active_chatbot_subscription(account, ev_sub_id):
+            logger.info(
+                f"{wc.ctx}Acesso ao chatbot mantido para {wc.customer_email}: "
+                f"outra assinatura ativa/trial do chatbot no cliente Stripe "
+                f"(evento trata da assinatura {ev_sub_id})."
+            )
+        else:
+            _set_account_chatbot_access(account, False, wc, revoke_msg)
+    elif not is_chat:
+        try:
+            if account:
+                remove_user(
+                    account.gcp_email or account.email,
+                    event_context=wc.event_context,
+                )
+            else:
+                remove_user(wc.customer_email, event_context=wc.event_context)
+        except Exception as e:
+            logger.error(f"{wc.ctx}{e}")
+
+
 def list_user(group_key: str = None):
     """List users from google group"""
     if not group_key:
@@ -272,71 +444,41 @@ def update_customer(event: Event, **kwargs):
 
 def handle_subscription(event: Event):
     """Handle subscription status"""
-    if not getattr(event, "customer", None) or not getattr(event.customer, "email", None):
-        logger.warning(f"Webhook {event.type} abortado: cliente ou e-mail ausente.")
+    wc = require_webhook_customer_context(event, log_if_invalid=True)
+    if not wc:
         return
 
-    event_context = f"Webhook: {event.type} | Event ID: {event.id}"
-    ctx = f"[{event_context}] "
-
-    subscription = get_subscription(event, event_context=event_context)
-    account = Account.objects.filter(email=event.customer.email).first()
+    subscription = get_subscription(event, event_context=wc.event_context)
+    account = get_account_for_stripe_customer(event)
 
     status = event.data.get("object", {}).get("status")
-    is_chatbot_plan = (
-        get_product_slug(subscription, event, event_context=event_context) == "chatbot"
-    )
 
     if status in ["trialing", "active"]:
         if subscription:
-            logger.info(f"{ctx}Adicionando a inscrição do cliente {event.customer.email}")
+            logger.info(f"{wc.ctx}Adicionando a inscrição do cliente {wc.customer_email}")
             subscription.is_active = True
             subscription.save()
 
-        # Add user to google group if subscription exists or not
-        if account:
-            if is_chatbot_plan:
-                try:
-                    logger.info(
-                        f"{ctx}Liberando acesso ao chatbot para o cliente {event.customer.email}"
-                    )
-                    account.has_chatbot_access = True
-                    account.save(update_fields=["has_chatbot_access"])
-                except Exception as e:
-                    logger.error(f"{ctx}{e}")
-            else:
-                add_user(
-                    account.gcp_email or account.email, account=account, event_context=event_context
-                )
-        else:
-            if not is_chatbot_plan:
-                add_user(event.customer.email, account=None, event_context=event_context)
+        apply_active_subscription_entitlements(wc, subscription, account)
+    elif status == "incomplete":
+        if subscription:
+            logger.info(
+                f"{wc.ctx}Assinatura incompleta (checkout em andamento) para "
+                f"{wc.customer_email}; atualizando apenas o registro interno."
+            )
+            subscription.is_active = False
+            subscription.save()
+        return
     else:
         if subscription:
             logger.info(
-                f"{ctx}Removendo a inscrição do cliente {event.customer.email} "
+                f"{wc.ctx}Removendo a inscrição do cliente {wc.customer_email} "
                 f"(Status via Stripe: {status})"
             )
             subscription.is_active = False
             subscription.save()
-        # Remove user from google group if subscription exists or not
-        if is_chatbot_plan and account:
-            try:
-                logger.info(
-                    f"{ctx}Removendo acesso ao chatbot para o cliente {event.customer.email}"
-                )
-                account.has_chatbot_access = False
-                account.save(update_fields=["has_chatbot_access"])
-            except Exception as e:
-                logger.error(f"{ctx}{e}")
-        elif not is_chatbot_plan:
-            try:
-                if account:
-                    remove_user(account.gcp_email or account.email, event_context=event_context)
-                else:
-                    remove_user(event.customer.email, event_context=event_context)
-            except Exception as e:
-                logger.error(f"{ctx}{e}")
+
+        apply_inactive_subscription_entitlements(wc, subscription, account)
 
 
 @webhooks.handler("customer.subscription.updated")
@@ -354,118 +496,68 @@ def subscribe(event: Event, **kwargs):
 @webhooks.handler("customer.subscription.deleted")
 def unsubscribe(event: Event, **kwargs):
     """Remove customer from allowed google groups"""
-    if not getattr(event, "customer", None) or not getattr(event.customer, "email", None):
+    wc = require_webhook_customer_context(event, log_if_invalid=False)
+    if not wc:
         return
 
-    event_context = f"Webhook: {event.type} | Event ID: {event.id}"
-    ctx = f"[{event_context}] "
-
-    if subscription := get_subscription(event, event_context=event_context):
-        logger.info(f"{ctx}Removendo a inscrição do cliente {event.customer.email}")
+    subscription = get_subscription(event, event_context=wc.event_context)
+    if subscription:
+        logger.info(f"{wc.ctx}Removendo a inscrição do cliente {wc.customer_email}")
         subscription.is_active = False
         subscription.save()
 
-    account = Account.objects.filter(email=event.customer.email).first()
-    is_chatbot_plan = (
-        get_product_slug(subscription, event, event_context=event_context) == "chatbot"
-    )
-
-    if is_chatbot_plan and account:
-        try:
-            logger.info(f"{ctx}Removendo acesso ao chatbot para o cliente {event.customer.email}")
-            account.has_chatbot_access = False
-            account.save(update_fields=["has_chatbot_access"])
-        except Exception as e:
-            logger.error(f"{ctx}{e}")
-    elif not is_chatbot_plan:
-        # Remove user from google group if subscription exists or not
-        try:
-            if account:
-                remove_user(account.gcp_email or account.email, event_context=event_context)
-            else:
-                remove_user(event.customer.email, event_context=event_context)
-        except Exception as e:
-            logger.error(f"{ctx}{e}")
+    account = get_account_for_stripe_customer(event)
+    apply_inactive_subscription_entitlements(wc, subscription, account)
 
 
 @webhooks.handler("customer.subscription.paused")
 def pause_subscription(event: Event, **kwargs):
     """Pause customer subscription"""
-    if not getattr(event, "customer", None) or not getattr(event.customer, "email", None):
+    wc = require_webhook_customer_context(event, log_if_invalid=False)
+    if not wc:
         return
 
-    event_context = f"Webhook: {event.type} | Event ID: {event.id}"
-    ctx = f"[{event_context}] "
+    account = get_account_for_stripe_customer(event)
 
-    account = Account.objects.filter(email=event.customer.email).first()
-
-    if subscription := get_subscription(event, event_context=event_context):
-        logger.info(f"{ctx}Pausando a inscrição do cliente {event.customer.email}")
+    subscription = get_subscription(event, event_context=wc.event_context)
+    if subscription:
+        logger.info(f"{wc.ctx}Pausando a inscrição do cliente {wc.customer_email}")
         subscription.is_active = False
         subscription.save()
 
-    is_chatbot_plan = (
-        get_product_slug(subscription, event, event_context=event_context) == "chatbot"
+    apply_inactive_subscription_entitlements(
+        wc,
+        subscription,
+        account,
+        chatbot_revoke_message=(
+            f"Removendo acesso ao chatbot para o cliente {wc.customer_email} (Pausado)"
+        ),
     )
-
-    if is_chatbot_plan and account:
-        try:
-            logger.info(
-                f"{ctx}Removendo acesso ao chatbot para o cliente {event.customer.email} (Pausado)"
-            )
-            account.has_chatbot_access = False
-            account.save(update_fields=["has_chatbot_access"])
-        except Exception as e:
-            logger.error(f"{ctx}{e}")
-    elif not is_chatbot_plan:
-        try:
-            if account:
-                remove_user(account.gcp_email or account.email, event_context=event_context)
-            else:
-                remove_user(event.customer.email, event_context=event_context)
-        except Exception as e:
-            logger.error(f"{ctx}{e}")
 
 
 @webhooks.handler("customer.subscription.resumed")
 def resume_subscription(event: Event, **kwargs):
     """Resume customer subscription"""
-    if not getattr(event, "customer", None) or not getattr(event.customer, "email", None):
+    wc = require_webhook_customer_context(event, log_if_invalid=False)
+    if not wc:
         return
 
-    event_context = f"Webhook: {event.type} | Event ID: {event.id}"
-    ctx = f"[{event_context}] "
+    account = get_account_for_stripe_customer(event)
 
-    account = Account.objects.filter(email=event.customer.email).first()
-
-    if subscription := get_subscription(event, event_context=event_context):
-        logger.info(f"{ctx}Resumindo a inscrição do cliente {event.customer.email}")
+    subscription = get_subscription(event, event_context=wc.event_context)
+    if subscription:
+        logger.info(f"{wc.ctx}Resumindo a inscrição do cliente {wc.customer_email}")
         subscription.is_active = True
         subscription.save()
 
-    is_chatbot_plan = (
-        get_product_slug(subscription, event, event_context=event_context) == "chatbot"
+    apply_active_subscription_entitlements(
+        wc,
+        subscription,
+        account,
+        chatbot_grant_message=(
+            f"Liberando acesso ao chatbot para o cliente {wc.customer_email} (Resumido)"
+        ),
     )
-
-    if is_chatbot_plan and account:
-        try:
-            logger.info(
-                f"{ctx}Liberando acesso ao chatbot para o cliente {event.customer.email} (Resumido)"
-            )
-            account.has_chatbot_access = True
-            account.save(update_fields=["has_chatbot_access"])
-        except Exception as e:
-            logger.error(f"{ctx}{e}")
-    elif not is_chatbot_plan:
-        try:
-            if account:
-                add_user(
-                    account.gcp_email or account.email, account=account, event_context=event_context
-                )
-            else:
-                add_user(event.customer.email, account=None, event_context=event_context)
-        except Exception as e:
-            logger.error(f"{ctx}{e}")
 
 
 @webhooks.handler("setup_intent.succeeded")


### PR DESCRIPTION
## Contexto

Os webhooks do Stripe tratavam chatbot e BD Pro da mesma forma (Google Group), com a lógica de concessão/revogação de acesso duplicada em cada handler (`handle_subscription`, `unsubscribe`, `pause_subscription`, `resume_subscription`).

## Principais mudanças

1. **Refatoração dos webhooks do Stripe**
   Lógica repetida centralizada em helpers: `WebhookContext` (contexto validado uma vez por evento), `require_webhook_customer_context` (validação de cliente/e-mail) e `apply_active_subscription_entitlements`/`apply_inactive_subscription_entitlements` (concessão e revogação de acessos).

2. **Melhor separação chatbot e BD Pro**
   Cada tipo de assinatura passa a ter tratamento próprio: chatbot altera `account.has_chatbot_access`; demais produtos continuam no Google Group (`add_user`/`remove_user`).

3. **Múltiplas assinaturas**
   Ao cancelar/pausar, o acesso ao chatbot só é removido se não houver outra assinatura de chatbot ativa/trial no mesmo cliente Stripe (`_account_has_other_active_chatbot_subscription`).

4. **Melhoria na lógica do `setup_intent.succeeded`**
   Em vez de bloquear a criação de assinatura se existir qualquer assinatura ativa, verifica se já há assinatura do mesmo tipo (chatbot ou BD Pro) antes de criar uma nova — permitindo que um cliente tenha as duas simultaneamente.

5. **Status `incomplete`**
   Checkout em andamento só atualiza o registro interno (`is_active = False`), sem conceder ou revogar acessos.

6. **Proteção de admins**
   Contas admin não perdem acesso ao chatbot automaticamente (centralizado em `_set_account_chatbot_access`).
