### PR TITLE
fix: admin usa Prefect3Client para ativar/pausar flows e corrige resposta vazia do PATCH

### DIFF
--- a/backend/apps/admin_data_tools/_prefect3_client.py
+++ b/backend/apps/admin_data_tools/_prefect3_client.py
@@ -38,7 +38,8 @@ class Prefect3Client:
             method=method,
         )
         with urllib.request.urlopen(req) as r:
-            return json.load(r)
+            raw = r.read()
+            return json.loads(raw) if raw else None
 
     def iter_deployments(self, page_size: int = 200) -> Iterator[dict]:
         """Yield every deployment registered in Prefect 3, paginated.

--- a/backend/apps/admin_data_tools/admin.py
+++ b/backend/apps/admin_data_tools/admin.py
@@ -2,10 +2,7 @@
 from django.contrib import admin
 from django.utils import timezone
 
-from backend.apps.admin_data_tools.management.commands._disable_unhealthy_flow_schedules.service import (  # noqa: E501
-    FlowService,
-)
-
+from ._prefect3_client import Prefect3Client
 from .models import DisabledFlowSchedule
 
 
@@ -24,12 +21,12 @@ class DisabledFlowScheduleAdmin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         if change and "is_schedule_active" in form.changed_data:
-            service = FlowService()
+            client = Prefect3Client()
             if obj.is_schedule_active:
                 obj.reactivated_at = timezone.now()
-                service.set_flow_schedule(deployment_id=obj.deployment_id, active=True)
+                client.set_paused(obj.deployment_id, paused=False)
             else:
                 obj.reactivated_at = None
-                service.disable_flow_schedule(deployment_id=obj.deployment_id)
+                client.set_paused(obj.deployment_id, paused=True)
 
         super().save_model(request, obj, form, change)


### PR DESCRIPTION
## Resumo

Correções no `admin.py` e `_prefect3_client.py` encontradas durante testes locais.

- **`admin.py`** — `save_model` migrado de `FlowService` (Prefect 0) para `Prefect3Client.set_paused()`. Ao ativar um flow pelo Django admin, agora chama `PATCH /deployments/{id}` no Prefect 3 diretamente
- **`_prefect3_client.py`** — `_request` retornava erro ao tentar fazer `json.load` numa resposta vazia; o `PATCH /deployments/{id}` do Prefect 3 retorna 204 sem body. Corrigido para retornar `None` quando o body é vazio

## Referências

- Issue: #1030
- PR original: #1029