### PR TITLE
feat: adicionado mutation para trial do chatbot

### DIFF
--- a/backend/apps/account_payment/graphql.py
+++ b/backend/apps/account_payment/graphql.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
+from datetime import timedelta
 
 import stripe
 from django.conf import settings
@@ -7,12 +8,14 @@ from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.db import IntegrityError, transaction
 from django.db.models import Q
+from django.utils import timezone
 from djstripe.models import Customer as DJStripeCustomer
 from djstripe.models import Price as DJStripePrice
 from djstripe.models import Subscription as DJStripeSubscription
 from graphene import (
     ID,
     Boolean,
+    DateTime,
     Field,
     Float,
     InputObjectType,
@@ -30,6 +33,10 @@ from stripe import Customer as StripeCustomer
 from stripe import SetupIntent
 
 from backend.apps.account.models import Account, Subscription
+from backend.apps.account_payment.trials import (
+    account_eligible_for_bdpro_stripe_trial,
+    account_eligible_for_chatbot_stripe_trial,
+)
 from backend.apps.account_payment.webhooks import add_user, is_email_in_group, remove_user
 from backend.custom.environment import get_backend_url
 from backend.custom.graphql_base import CountableConnection, PlainTextNode
@@ -214,7 +221,6 @@ class StripeSubscribeMutation(Mutation):
     def mutate(cls, root, info, price_id, coupon=None):
         try:
             admin = info.context.user
-            internal_subscriptions = admin.internal_subscription.all()
 
             price = DJStripePrice.objects.get(djstripe_id=price_id)
             new_product_code = price.product.metadata.get("code", "")
@@ -222,7 +228,7 @@ class StripeSubscribeMutation(Mutation):
 
             for s in [
                 *admin.subscription_set.all(),
-                *internal_subscriptions,
+                *admin.internal_subscription.all(),
             ]:
                 if s.is_active:
                     try:
@@ -235,7 +241,10 @@ class StripeSubscribeMutation(Mutation):
                     if is_new_chatbot == is_existing_chatbot:
                         return cls(errors=["Conta possui inscrição ativa para este tipo de plano"])
 
-            is_trial_active = len(internal_subscriptions) == 0
+            if is_new_chatbot:
+                is_trial_active = account_eligible_for_chatbot_stripe_trial(admin)
+            else:
+                is_trial_active = account_eligible_for_bdpro_stripe_trial(admin)
             promotion_code = None
 
             try:
@@ -277,6 +286,43 @@ class StripeSubscribeMutation(Mutation):
                 return cls(client_secret=payment_intent.client_secret)
 
             return cls(client_secret=setup_intent.client_secret)
+        except Exception as e:
+            logger.error(e)
+            return cls(errors=[str(e)])
+
+
+class StartChatbotTrialMutation(Mutation):
+    """Start a card-free 7-day chatbot trial via a Stripe
+    subscription that auto-cancels at trial end."""
+
+    chatbot_trial_ends_at = DateTime()
+    errors = List(String)
+
+    class Arguments:
+        price_id = ID(required=True)
+
+    @classmethod
+    @login_required
+    def mutate(cls, root, info, price_id):
+        try:
+            account = info.context.user
+            price = DJStripePrice.objects.get(djstripe_id=price_id)
+
+            if "chatbot" not in price.product.metadata.get("code", "").lower():
+                return cls(errors=["[Chatbot] Este preço não pertence ao produto chatbot."])
+
+            if not account_eligible_for_chatbot_stripe_trial(account):
+                return cls(errors=["[Chatbot] Trial do chatbot indisponível para esta conta."])
+
+            customer, _ = DJStripeCustomer.get_or_create(account)
+
+            trial_end = timezone.now() + timedelta(days=7)
+            customer.subscribe(
+                price=price.id,
+                trial_end=int(trial_end.timestamp()),
+                cancel_at=int(trial_end.timestamp()),
+            )
+            return cls(chatbot_trial_ends_at=trial_end)
         except Exception as e:
             logger.error(e)
             return cls(errors=[str(e)])
@@ -696,6 +742,7 @@ class Mutation(ObjectType):
     create_stripe_customer = StripeCustomerCreateMutation.Field()
     update_stripe_customer = StripeCustomerUpdateMutation.Field()
     create_stripe_subscription = StripeSubscribeMutation.Field()
+    start_chatbot_trial = StartChatbotTrialMutation.Field()
     delete_stripe_subscription = StripeSubscriptionDeleteMutation.Field()
     delete_stripe_subscription_immediately = StripeSubscriptionDeleteImmediatelyMutation.Field()
     add_stripe_subscription_member = StripeSubscriptionAddMemberMutation.Field()

--- a/backend/apps/account_payment/trials.py
+++ b/backend/apps/account_payment/trials.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from djstripe.models import Subscription as DJStripeSubscription
+
+from backend.apps.account.models import Account
+
+IGNORED_SUBSCRIPTION_STATUSES = frozenset({"incomplete", "incomplete_expired"})
+
+
+def djstripe_subscription_is_chatbot(dj_sub: DJStripeSubscription) -> bool:
+    try:
+        if getattr(dj_sub, "plan", None) and getattr(dj_sub.plan, "product", None):
+            return dj_sub.plan.product.metadata.get("code", "") == "chatbot"
+        if hasattr(dj_sub, "items") and dj_sub.items.first():
+            item = dj_sub.items.first()
+            if getattr(item, "price", None) and getattr(item.price, "product", None):
+                return item.price.product.metadata.get("code", "") == "chatbot"
+    except Exception:
+        pass
+    return False
+
+
+def account_has_active_chatbot_stripe_subscription(
+    account: Account,
+    exclude_stripe_subscription_id: str | None = None,
+) -> bool:
+    qs = DJStripeSubscription.objects.filter(
+        customer__subscriber=account,
+        status__in=["active", "trialing"],
+    )
+    if exclude_stripe_subscription_id:
+        qs = qs.exclude(id=exclude_stripe_subscription_id)
+    return any(djstripe_subscription_is_chatbot(s) for s in qs.iterator(chunk_size=20))
+
+
+def account_djstripe_subscriptions(account: Account):
+    return DJStripeSubscription.objects.filter(customer__subscriber=account).exclude(
+        status__in=IGNORED_SUBSCRIPTION_STATUSES
+    )
+
+
+def account_has_prior_non_chatbot_subscription(account: Account) -> bool:
+    """True if the account ever had a BD Pro (non-chatbot) Stripe subscription."""
+    return any(
+        not djstripe_subscription_is_chatbot(s)
+        for s in account_djstripe_subscriptions(account).iterator(chunk_size=20)
+    )
+
+
+def account_has_prior_chatbot_subscription(account: Account) -> bool:
+    """True if the account ever had a chatbot Stripe subscription."""
+    return any(
+        djstripe_subscription_is_chatbot(s)
+        for s in account_djstripe_subscriptions(account).iterator(chunk_size=20)
+    )
+
+
+def account_eligible_for_bdpro_stripe_trial(account: Account) -> bool:
+    return not account_has_prior_non_chatbot_subscription(account)
+
+
+def account_eligible_for_chatbot_stripe_trial(account: Account) -> bool:
+    return not account_has_prior_chatbot_subscription(account)

--- a/backend/apps/account_payment/webhooks.py
+++ b/backend/apps/account_payment/webhooks.py
@@ -16,6 +16,12 @@ from loguru import logger
 from stripe import Customer as StripeCustomer
 
 from backend.apps.account.models import Account, Subscription
+from backend.apps.account_payment.trials import (
+    account_eligible_for_bdpro_stripe_trial,
+    account_eligible_for_chatbot_stripe_trial,
+    account_has_active_chatbot_stripe_subscription,
+    djstripe_subscription_is_chatbot,
+)
 from backend.custom.client import send_discord_message as send
 from backend.custom.environment import get_backend_url, is_dev, is_stg
 
@@ -214,57 +220,18 @@ def subscription_product_is_chatbot(
 
 
 def _djstripe_subscription_is_chatbot(dj_sub: DJStripeSubscription) -> bool:
-    """Check whether a DJStripeSubscription's product is the chatbot product.
-
-    Walks the subscription's plan/price to the Stripe Product metadata,
-    mirroring `get_product_slug`'s traversal but operating directly on a
-    `DJStripeSubscription` instance instead of an event or internal model.
-
-    Args:
-        dj_sub: The dj-stripe `Subscription` instance to inspect.
-
-    Returns:
-        `True` if the product's `code` metadata is exactly `"chatbot"`.
-        `False` if it can't be resolved or any lookup raises.
-    """
-    try:
-        if getattr(dj_sub, "plan", None) and getattr(dj_sub.plan, "product", None):
-            return dj_sub.plan.product.metadata.get("code", "") == "chatbot"
-        if hasattr(dj_sub, "items") and dj_sub.items.first():
-            item = dj_sub.items.first()
-            if getattr(item, "price", None) and getattr(item.price, "product", None):
-                return item.price.product.metadata.get("code", "") == "chatbot"
-    except Exception:
-        pass
-    return False
+    return djstripe_subscription_is_chatbot(dj_sub)
 
 
 def _account_has_other_active_chatbot_subscription(
     account: Account,
     exclude_stripe_subscription_id: str | None,
 ) -> bool:
-    """Check if an account has another active/trialing chatbot subscription.
-
-    Used when revoking chatbot access, to avoid removing it if the customer
-    still has a second active or trialing chatbot subscription (e.g. after
-    switching plans).
-
-    Args:
-        account: The account whose Stripe subscriptions to check.
-        exclude_stripe_subscription_id: Stripe subscription id to exclude
-            from the check (typically the one the current event is about).
-
-    Returns:
-        `True` if at least one other active/trialing chatbot subscription
-        exists for the account's Stripe customer.
-    """
-    qs = DJStripeSubscription.objects.filter(
-        customer__subscriber=account,
-        status__in=["active", "trialing"],
+    """True if the customer still has another active/trialing Stripe sub for the chatbot product."""
+    return account_has_active_chatbot_stripe_subscription(
+        account,
+        exclude_stripe_subscription_id=exclude_stripe_subscription_id,
     )
-    if exclude_stripe_subscription_id:
-        qs = qs.exclude(id=exclude_stripe_subscription_id)
-    return any(_djstripe_subscription_is_chatbot(s) for s in qs.iterator(chunk_size=20))
 
 
 def _account_has_active_non_chatbot_subscription(account: Account) -> bool:
@@ -959,8 +926,28 @@ def setup_intent_succeeded(event: Event, **kwargs):
     else:
         discounts = []
 
-    logger.info(f"{ctx}Add subscription to user {event.customer.email}")
-    customer.subscribe(price=price_id, trial_period_days=7, discounts=discounts)
+    account = getattr(customer, "subscriber", None) or get_account_for_stripe_customer(event)
+    subscribe_kwargs = {"price": price_id, "discounts": discounts}
+
+    skip_trial = False
+    if is_chatbot_price:
+        skip_trial = bool(account and not account_eligible_for_chatbot_stripe_trial(account))
+    else:
+        skip_trial = bool(account and not account_eligible_for_bdpro_stripe_trial(account))
+
+    if not skip_trial:
+        subscribe_kwargs["trial_period_days"] = 7
+
+    if skip_trial:
+        product_label = "chatbot" if is_chatbot_price else "bd_pro"
+        logger.info(
+            f"{ctx}Cliente {event.customer.email} não elegível a trial do {product_label}; "
+            "assinatura criada sem período de trial."
+        )
+    else:
+        logger.info(f"{ctx}Add subscription to user {event.customer.email}")
+
+    customer.subscribe(**subscribe_kwargs)
 
 
 # Reference


### PR DESCRIPTION
### Novo módulo `trials.py`

- Centraliza a lógica de elegibilidade para trial.
- BD Pro: trial só se a conta nunca teve assinatura Stripe não-chatbot.
- Chatbot: trial só se a conta nunca teve assinatura Stripe de chatbot.
- Inclui helpers para identificar assinaturas chatbot e checar histórico/assinaturas ativas.

### Nova mutation em `account_payment/graphql.py`

- `StripeSubscribeMutation`: deixa de usar `internal_subscriptions` como critério de trial; passa a usar as funções de elegibilidade por produto (BD Pro vs chatbot).
- Nova mutation `startChatbotTrial`: trial de 7 dias do chatbot sem cartão, via assinatura Stripe que cancela automaticamente no fim do trial (trial_end + cancel_at).

### Atualização nos webhooks

- Refatoração para reutilizar `trials.py`.
- No `setup_intent_succeeded`: aplica `trial_period_days=7` só se a conta for elegível; caso contrário, cria a assinatura sem trial, com log explicando o motivo.
