### PR TITLE
fix: atualiza disabled_at ao desativar flow via webhook

### DIFF
--- a/backend/apps/admin_data_tools/models.py
+++ b/backend/apps/admin_data_tools/models.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from django.db import models
+from django.utils import timezone
 
 
 class DisabledFlowSchedule(models.Model):
     flow_name = models.CharField(max_length=255, unique=True)
     deployment_id = models.CharField(max_length=255)
-    disabled_at = models.DateTimeField(auto_now_add=True)
+    disabled_at = models.DateTimeField(default=timezone.now)
     is_schedule_active = models.BooleanField(default=False)
     reactivated_at = models.DateTimeField(null=True, blank=True)
 

--- a/backend/apps/admin_data_tools/views.py
+++ b/backend/apps/admin_data_tools/views.py
@@ -258,7 +258,8 @@ class FlowFailedWebhookView(View):
             client.set_paused(deployment_id, paused=True)
             record.is_schedule_active = False
             record.reactivated_at = None
-            record.save(update_fields=["is_schedule_active", "reactivated_at"])
+            record.disabled_at = datetime.now(tz=timezone.utc)
+            record.save(update_fields=["is_schedule_active", "reactivated_at", "disabled_at"])
             logger.info(f"Disabled {record.flow_name} after failure")
             return JsonResponse({"status": "ok", "action": "disabled"})
 


### PR DESCRIPTION
## Summary

O campo `disabled_at` usava `auto_now_add=True` e nunca era atualizado após a criação do registro. A view agora seta `disabled_at = now()` ao desativar o flow, refletindo o momento real do desativamento.