### PR TITLE
feat(search): spatial coverage facet + exclude world from lower-level filters

### DIFF
--- a/backend/apps/api/v1/search_views.py
+++ b/backend/apps/api/v1/search_views.py
@@ -71,10 +71,12 @@ class DatasetSearchForm(FacetedSearchForm):
                         coverage_patterns = ["_".join(parts[:i]) for i in range(1, len(parts))]
                         coverage_patterns.append(coverage)  # Add the full coverage too
 
-                        # Build OR condition for all valid levels, including world
+                        # Build OR condition for the selected area and its ancestors
+                        # (broader coverage that contains it). World is intentionally
+                        # excluded: global datasets are counted only under the
+                        # International bucket, not under every lower-level area.
                         patterns = " OR ".join(
-                            f'spatial_coverage_exact:"{pattern}"'
-                            for pattern in coverage_patterns + ["world"]
+                            f'spatial_coverage_exact:"{pattern}"' for pattern in coverage_patterns
                         )
                         coverage_queries.append(f"({patterns})")
 

--- a/backend/apps/api/v1/search_views.py
+++ b/backend/apps/api/v1/search_views.py
@@ -154,6 +154,7 @@ class DatasetSearchView(FacetedSearchView):
         sqs = sqs.facet("organization_slug", size=facet_size)
         sqs = sqs.facet("tag_slug", size=facet_size)
         sqs = sqs.facet("entity_slug", size=facet_size)
+        sqs = sqs.facet("spatial_coverage", size=facet_size)
 
         # Parse facet counts from Elasticsearch response
         facets = {}
@@ -171,6 +172,7 @@ class DatasetSearchView(FacetedSearchView):
             ("organization_slug", "organizations", Organization),
             ("tag_slug", "tags", Tag),
             ("entity_slug", "observation_levels", Entity),
+            ("spatial_coverage", "spatial_coverages", Area),
         ]
 
         for es_field, api_field, model in facet_mappings:


### PR DESCRIPTION
## Summary

Same two `/search` changes as basedosdados/backend#1038 (merged to `staging`), targeted at `main`.

1. **Add `spatial_coverages` to the aggregations.** `get_facets()` now requests the `spatial_coverage` facet and translates slugs via `Area` (`name_{locale}`), mirroring the existing `organizations` facet. Output shape matches the other facets: `[{key, count, name, fallback}]`.
2. **Exclude `world` from lower-level spatial filters.** Selecting a specific area OR'd in `spatial_coverage_exact:"world"`, so filtering by Brazil returned Brazil-only datasets **plus every global dataset** (294 → 673). Global datasets are indexed as `["world"]` only (`get_spatial_coverage`), so the facet counts were already exclusive; this aligns the filter results with them. Ancestor rollup is preserved (a state still matches its country); only `world` is dropped.

Backs the website spatial-coverage filter (basedosdados/website#1594).

## Test plan

Verified against a local stack (Elasticsearch + fixtures, `rebuild_index`):
- `/search` aggregations include `spatial_coverages` with correct localized names/counts.
- `?spatial_coverage=br` → **294** (was 673); `world` → 379; `us` → 175 (no world leak); `br_sp` → 306 (São Paulo + country rollup, no world).

## Not included here

The `world` **Area rename** to "International"/"Internacional" is a data change (updates the `Area` row's names; slug stays `world`). It resolves at query time (no reindex) — apply it on the target DB or as a data migration, not via this code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)