### PR TITLE
fix: corrige update_table_metadata_task para bucket requester pays do GCS

### DIFF
--- a/backend/apps/api/v1/tasks.py
+++ b/backend/apps/api/v1/tasks.py
@@ -12,7 +12,7 @@ from pandas import read_gbq
 from requests import get
 
 from backend.apps.api.v1.models import Dataset, RawDataSource, Table, TableNeighbor
-from backend.custom.client import Messenger, get_gbq_client, get_gcs_client
+from backend.custom.client import Messenger, get_gbq_client, get_gcs_client, send_discord_message
 from backend.custom.environment import production_task
 
 logger = logger.bind(module="api.v1")
@@ -66,6 +66,10 @@ def update_table_metadata_task(table_pks: list[str] = None):
 
         if bq_table.table_type == "VIEW":
             try:
+                # `basedosdados` is a requester pays bucket, so listing it requires a
+                # billing project. `Client.bucket` only builds a handle: no request is
+                # made until `list_blobs` runs, inside this try.
+                cs_bucket = cs_client.bucket("basedosdados", user_project=cs_client.project)
                 file_size: int = 0
                 for blob in cs_bucket.list_blobs(prefix=table.gcs_slug):
                     file_size += blob.size
@@ -73,9 +77,14 @@ def update_table_metadata_task(table_pks: list[str] = None):
             except Exception as exc:
                 logger.warning(exc)
 
-    bq_client = get_gbq_client()
-    cs_client = get_gcs_client()
-    cs_bucket = cs_client.get_bucket("basedosdados")
+    try:
+        bq_client = get_gbq_client()
+        cs_client = get_gcs_client()
+    except Exception as exc:
+        # Nothing below has run yet, so `messenger` would have no lines to send and the
+        # failure would be silent. Report it before re-raising.
+        send_discord_message(f"`update_table_metadata_task` falhou ao iniciar: `{exc}`")
+        raise
 
     messenger = Messenger("Verifique os metadados dos conjuntos:")
 


### PR DESCRIPTION
### Purpose

`update_table_metadata_task` has not updated a single table since **27 February 2026**. It runs every weekday at 06:00 and crashes on its third statement, before the table loop, so it processes nothing — and it does so silently.

The crash, captured from the `api-prod` pod on 21 July while the task ran (triggered from the admin action "Atualizar metadados das tabelas"):

```
File "/app/backend/apps/api/v1/tasks.py", line 78, in update_table_metadata_task
    cs_bucket = cs_client.get_bucket("basedosdados")

google.api_core.exceptions.BadRequest: 400 GET
https://storage.googleapis.com/storage/v1/b/basedosdados?projection=noAcl&prettyPrint=false:
Bucket is a requester pays bucket but no user project provided.
```

The `basedosdados` bucket is requester pays. `get_gcs_client()` builds `GCSClient(credentials=...)` with no `user_project`, so `get_bucket` returns 400. The 27 February cutoff is when the bucket was converted.

Two things made this invisible for five months:

1. **The failure is before the loop.** `Messenger` only posts to Discord once it has collected per-table error lines, and the task never reaches the loop — so `messenger.send()` sends nothing.
2. **The pod stays healthy.** huey runs as a background subshell inside the `api-prod` container, and only the web server is probed. `kubectl` shows `1/1 Running`; the site and API serve normally.

**Impact.** Across the production backend, **130 of 858 eligible tables** carry `uncompressed_file_size = NULL` *and* `number_rows = NULL` (measured 21 July via cursor-paginated `allTable`). Every dataset registered after 27 February is affected, including `us_bls_cpi`, `us_ed_ipeds`, `us_census_*`, `br_bd_diretorios_us`, `world_un_wpp`, `af_afrobarometer_survey`, `gb_eric_ess` and `in_tcpd_elections`.

Null size is not cosmetic — it disables downloads. `contains_direct_download_free` and `contains_direct_download_paid` both return `False` when the field is `None` (`models.py:1202-1211`), so those 130 tables offer no download on the site.

### Description

- **Pass `user_project` when building the bucket handle.** `Client.bucket()` constructs locally and issues no request, so the call can no longer fail at task start.
- **Move the bucket into the `VIEW` branch of `get_uncompressed_file_size`**, the only place that uses it, inside the existing `try`. A GCS problem can now at most cost the size of view-backed tables; it can no longer take down row and column counts for every table in the database.
- **Report client-construction failures to Discord before re-raising.** Any exception in that pre-loop section is otherwise unreportable, which is the root cause of the five-month silence rather than of the crash itself.

### Checklist

- [x] I have reviewed the code changes.
- [ ] I have tested the changes locally. — see below; the task needs production GCS/BigQuery credentials and cannot be exercised from a workstation.
- [ ] I have updated the documentation if needed. — no documentation covers this task.
- [ ] I have added/modified tests to ensure the changes are valid. — see "Next steps".

### Testing and evidence

What was verified:

- **The diagnosis is observed, not inferred.** The traceback above is from the live `api-prod-6f87bf74b-bhhnl` pod, from a real execution carrying the four `us_bls_cpi` table UUIDs.
- **The BigQuery data is fine.** `basedosdados.us_bls_cpi.__TABLES__` reports `monthly` at 2,638,757 rows / 200.5 MB. `bq_table.num_bytes` is populated for ordinary tables, so once the task runs to completion these tables fill on the first sweep with no backfill script.
- **Scope of the outage** comes from a cursor-paginated `allTable` query (note that `first: N` truncates silently, so a single-page count would have understated it). Last successful sweep: 432 tables on 26 February, 250 on 27 February — both visible as `updated_at` clusters at 06:00–07:00 UTC. Nothing since.
- `ruff check` and `ruff format --diff` pass on the changed file.

What was **not** verified: the task itself was not run. It requires the worker's service account for both BigQuery and requester-pays GCS. The correctness of `user_project=cs_client.project` for the requester-pays call is therefore reasoned, not executed — worth watching on the first run after deploy.

Suggested check after merge: trigger the admin action on one dataset, confirm `uncompressed_file_size` and `number_rows` populate, then let the 06:00 schedule sweep the rest.

### Next steps

Two related problems this PR deliberately leaves alone:

1. **The sweep aborts once the Discord message fills.** The loop breaks on `messenger.is_full` (~1600 chars, roughly 7–10 failing tables), and a failing table never gets its `updated_at` bumped — so it stays at the head of the `order_by("updated_at")` queue permanently. Once enough tables fail consistently, the sweep can never reach anything behind them. The 26 February run stopping at 432 tables and the 27th at 250 is consistent with this already happening.
2. **huey is unsupervised.** `start-server.sh` launches it as `(python manage.py run_huey &)` inside the web container. Kubernetes cannot restart what it cannot see, and if `api-prod` is ever scaled past one replica, every replica runs the same crontab concurrently. It belongs in its own Deployment.

Neither is the cause of this outage, and both are worth separate PRs.
