### PR TITLE
feat: expose the Stripe price id on StripePriceNode

### DIFF
--- a/backend/apps/account_payment/graphql.py
+++ b/backend/apps/account_payment/graphql.py
@@ -49,6 +49,7 @@ else:
 
 class StripePriceNode(DjangoObjectType):
     _id = ID(name="_id")
+    stripe_price_id = String()
     amount = Float()
     interval = String()
     trial_period_days = String()
@@ -69,6 +70,12 @@ class StripePriceNode(DjangoObjectType):
 
     def resolve__id(root, info):
         return root.djstripe_id
+
+    def resolve_stripe_price_id(root, info):
+        # The Stripe price id (e.g. "price_..."), stable and verifiable in the Stripe
+        # dashboard, unlike the environment-specific djstripe PK exposed as `_id`. Lets the
+        # website select exactly which prices to sell instead of guessing by amount.
+        return root.id
 
     def resolve_amount(root, info):
         if root.unit_amount:


### PR DESCRIPTION
## What
Adds `stripePriceId` (the Stripe `price_…` id) to `StripePriceNode` in the payments GraphQL API.

## Why
The website selects which price to sell by matching an active price on (product, interval, amount) — fragile once a product has multiple active prices (legacy tiers, gift prices, and the per-currency BRL/USD prices for the international rollout). Exposing the stable, dashboard-verifiable Stripe price id lets the website select prices by explicit id. Companion: basedosdados/website (`fix/select-prices-by-id`).

## Change
`StripePriceNode.resolve_stripe_price_id` returns `root.id` (the djstripe Price's Stripe id). The existing `_id` (djstripe PK) that checkout uses is unchanged. ~7 lines, no migration.

## Deploy note
Deploy to an environment before the website PR goes live there — the site will start requesting this field on `allStripePrice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
