### PR TITLE
feat(payment): charge card-country regional price at checkout

### DIFF
--- a/backend/apps/account_payment/graphql.py
+++ b/backend/apps/account_payment/graphql.py
@@ -52,6 +52,7 @@ class StripePriceNode(DjangoObjectType):
     stripe_price_id = String()
     amount = Float()
     interval = String()
+    region = String()
     trial_period_days = String()
     product_name = String()
     product_slug = String()
@@ -85,6 +86,12 @@ class StripePriceNode(DjangoObjectType):
     def resolve_interval(root, info):
         if recurring := root.recurring:
             return recurring.get("interval", "")
+
+    def resolve_region(root, info):
+        # The pricing region this price sells in ("br", "latam", "intl"), from the
+        # price's `region` metadata. Lets the storefront show the right currency by
+        # domain, and mirrors the tag the checkout webhook enforces server-side.
+        return root.metadata.get("region", "")
 
     def resolve_trial_period_days(root, info):
         if recurring := root.recurring:

--- a/backend/apps/account_payment/regional_pricing.py
+++ b/backend/apps/account_payment/regional_pricing.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""Region-aware pricing: map a card's country to a pricing region and pick the
+matching Stripe price.
+
+Data Basis sells the same products (BD Pro, Chatbot) at different prices by
+region: Brazilian cards in BRL, Spanish-speaking Latin America and the wider
+world in USD at region-specific tiers. Each Stripe price carries a ``region``
+metadata tag (``br``, ``latam`` or ``intl``); its product carries a ``code`` tag
+(``bd_pro``, ``chatbot``) and its recurring block carries the interval
+(``month``, ``year``).
+
+The checkout page decides which price to *show*; this module is the server-side
+guardrail that decides which price to *charge*, from the country of the card the
+customer actually used. It exists so that switching to a cheaper regional
+storefront (e.g. a US customer checking out on the Brazilian domain) does not
+change what they pay.
+
+The functions here are pure: they take Price-like objects and strings and never
+touch the database or the Stripe API. The webhook glue that reads the card
+country and loads prices lives in ``webhooks.py``.
+"""
+
+from __future__ import annotations
+
+DEFAULT_REGION = "intl"
+
+# Spanish-speaking Latin America, as ISO 3166-1 alpha-2 codes. Brazil is its own
+# region (``br``); every country not listed here bills at the international
+# (``intl``) tier.
+_LATAM_COUNTRIES = frozenset(
+    {
+        "AR",  # Argentina
+        "BO",  # Bolivia
+        "CL",  # Chile
+        "CO",  # Colombia
+        "CR",  # Costa Rica
+        "CU",  # Cuba
+        "DO",  # Dominican Republic
+        "EC",  # Ecuador
+        "GT",  # Guatemala
+        "HN",  # Honduras
+        "MX",  # Mexico
+        "NI",  # Nicaragua
+        "PA",  # Panama
+        "PE",  # Peru
+        "PY",  # Paraguay
+        "SV",  # El Salvador
+        "UY",  # Uruguay
+        "VE",  # Venezuela
+    }
+)
+
+
+def country_to_region(country: str | None) -> str:
+    """Map an ISO 3166-1 alpha-2 country code to a pricing region.
+
+    Args:
+        country: Two-letter country code from the payment card
+            (case-insensitive), or ``None``/empty when unknown.
+
+    Returns:
+        ``"br"`` for Brazil, ``"latam"`` for Spanish-speaking Latin America, and
+        ``"intl"`` for everywhere else or when the country is unknown.
+    """
+    if not country:
+        return DEFAULT_REGION
+    code = country.strip().upper()
+    if code == "BR":
+        return "br"
+    if code in _LATAM_COUNTRIES:
+        return "latam"
+    return DEFAULT_REGION
+
+
+def _price_region(price) -> str:
+    return (getattr(price, "metadata", None) or {}).get("region", "")
+
+
+def _price_code(price) -> str:
+    product = getattr(price, "product", None)
+    if product is None:
+        return ""
+    return (getattr(product, "metadata", None) or {}).get("code", "")
+
+
+def _price_interval(price) -> str:
+    return (getattr(price, "recurring", None) or {}).get("interval", "")
+
+
+def resolve_regional_price_id(prices, original_price_id: str, region: str) -> str:
+    """Pick the Stripe price id to charge, given the customer's region.
+
+    Given the price the customer checked out with and their card's region, return
+    the id of the equivalent price (same product ``code`` and billing interval)
+    tagged for that region. Falls back to ``original_price_id`` whenever a
+    confident swap cannot be made: the original price is not in ``prices``, it
+    already matches the region, it lacks a code or interval, or no active sibling
+    price for the region exists.
+
+    The function never raises and never returns an id that is not present in
+    ``prices``. This conservatism is deliberate — a wrong or missing regional
+    price must never block a subscription from being created.
+
+    Args:
+        prices: Iterable of dj-stripe ``Price``-like objects. Each needs ``.id``,
+            ``.metadata`` (with ``region``), ``.recurring`` (with ``interval``),
+            ``.product.metadata`` (with ``code``), and ``.active``.
+        original_price_id: The Stripe price id encoded in the checkout.
+        region: Target region from the card country (``br``/``latam``/``intl``).
+
+    Returns:
+        The Stripe price id to charge — either a region-matched sibling or, when
+        no confident match exists, ``original_price_id`` unchanged.
+    """
+    prices = list(prices)
+
+    original = next((p for p in prices if p.id == original_price_id), None)
+    if original is None:
+        return original_price_id
+    if _price_region(original) == region:
+        return original_price_id
+
+    code = _price_code(original)
+    interval = _price_interval(original)
+    if not code or not interval:
+        return original_price_id
+
+    for candidate in prices:
+        if (
+            candidate.id != original_price_id
+            and getattr(candidate, "active", True)
+            and _price_code(candidate) == code
+            and _price_interval(candidate) == interval
+            and _price_region(candidate) == region
+        ):
+            return candidate.id
+
+    return original_price_id

--- a/backend/apps/account_payment/test_regional_pricing.py
+++ b/backend/apps/account_payment/test_regional_pricing.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+"""Tests for region-aware pricing.
+
+The decision logic lives in pure functions (``country_to_region`` and
+``resolve_regional_price_id``) and is tested directly with stub prices — no
+database, no Stripe. The webhook glue (``_regional_price_id``, ``_card_country``)
+is tested with mocks for the Stripe API and the price queryset.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from backend.apps.account_payment.regional_pricing import (
+    country_to_region,
+    resolve_regional_price_id,
+)
+from backend.apps.account_payment.webhooks import (
+    _card_country,
+    _regional_price_id,
+)
+
+
+def _price(price_id, region, code, interval, active=True):
+    """Build a dj-stripe ``Price``-like stub."""
+    return SimpleNamespace(
+        id=price_id,
+        active=active,
+        metadata={"region": region},
+        recurring={"interval": interval},
+        product=SimpleNamespace(metadata={"code": code}),
+    )
+
+
+# A realistic catalogue: BD Pro and Chatbot, monthly and yearly, in three regions.
+CATALOGUE = [
+    _price("price_br_pro_m", "br", "bd_pro", "month"),
+    _price("price_latam_pro_m", "latam", "bd_pro", "month"),
+    _price("price_intl_pro_m", "intl", "bd_pro", "month"),
+    _price("price_br_pro_y", "br", "bd_pro", "year"),
+    _price("price_intl_pro_y", "intl", "bd_pro", "year"),
+    _price("price_br_cb_m", "br", "chatbot", "month"),
+    _price("price_intl_cb_m", "intl", "chatbot", "month"),
+]
+
+
+# ---------------------------------------------------------------------------
+# country_to_region
+# ---------------------------------------------------------------------------
+
+
+class TestCountryToRegion:
+    def test_brazil_is_br(self):
+        assert country_to_region("BR") == "br"
+
+    def test_is_case_insensitive(self):
+        assert country_to_region("br") == "br"
+        assert country_to_region("mx") == "latam"
+
+    def test_whitespace_is_trimmed(self):
+        assert country_to_region("  BR  ") == "br"
+
+    def test_spanish_latam_is_latam(self):
+        for code in ("AR", "MX", "CO", "CL", "PE", "UY", "VE", "DO"):
+            assert country_to_region(code) == "latam", code
+
+    def test_rest_of_world_is_intl(self):
+        for code in ("US", "GB", "PT", "DE", "JP", "AU", "ZZ"):
+            assert country_to_region(code) == "intl", code
+
+    def test_unknown_country_is_intl(self):
+        assert country_to_region(None) == "intl"
+        assert country_to_region("") == "intl"
+
+
+# ---------------------------------------------------------------------------
+# resolve_regional_price_id
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRegionalPriceId:
+    def test_swaps_br_to_intl_same_product_and_interval(self):
+        # A US card checking out the Brazilian monthly BD Pro price gets the
+        # international monthly BD Pro price.
+        assert resolve_regional_price_id(CATALOGUE, "price_br_pro_m", "intl") == "price_intl_pro_m"
+
+    def test_swaps_br_to_latam(self):
+        assert (
+            resolve_regional_price_id(CATALOGUE, "price_br_pro_m", "latam") == "price_latam_pro_m"
+        )
+
+    def test_no_swap_when_region_already_matches(self):
+        assert (
+            resolve_regional_price_id(CATALOGUE, "price_intl_pro_m", "intl") == "price_intl_pro_m"
+        )
+
+    def test_keeps_original_when_no_sibling_for_region(self):
+        # Chatbot has no latam price in the catalogue.
+        assert resolve_regional_price_id(CATALOGUE, "price_br_cb_m", "latam") == "price_br_cb_m"
+
+    def test_keeps_original_when_not_in_catalogue(self):
+        assert resolve_regional_price_id(CATALOGUE, "price_unknown", "intl") == "price_unknown"
+
+    def test_interval_must_match(self):
+        # Yearly original must not be swapped for a monthly sibling.
+        catalogue = [
+            _price("price_br_pro_y", "br", "bd_pro", "year"),
+            _price("price_intl_pro_m", "intl", "bd_pro", "month"),
+        ]
+        assert resolve_regional_price_id(catalogue, "price_br_pro_y", "intl") == "price_br_pro_y"
+
+    def test_product_code_must_match(self):
+        # A chatbot original must not be swapped for a bd_pro sibling.
+        catalogue = [
+            _price("price_br_cb_m", "br", "chatbot", "month"),
+            _price("price_intl_pro_m", "intl", "bd_pro", "month"),
+        ]
+        assert resolve_regional_price_id(catalogue, "price_br_cb_m", "intl") == "price_br_cb_m"
+
+    def test_inactive_sibling_is_ignored(self):
+        catalogue = [
+            _price("price_br_pro_m", "br", "bd_pro", "month"),
+            _price("price_intl_pro_m", "intl", "bd_pro", "month", active=False),
+        ]
+        assert resolve_regional_price_id(catalogue, "price_br_pro_m", "intl") == "price_br_pro_m"
+
+    def test_untagged_original_still_swaps_to_region(self):
+        # A price with no region tag ("") differs from the target region, so a
+        # tagged sibling is still substituted.
+        catalogue = [
+            _price("price_legacy_pro_m", "", "bd_pro", "month"),
+            _price("price_intl_pro_m", "intl", "bd_pro", "month"),
+        ]
+        assert (
+            resolve_regional_price_id(catalogue, "price_legacy_pro_m", "intl") == "price_intl_pro_m"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _card_country
+# ---------------------------------------------------------------------------
+
+
+class TestCardCountry:
+    @patch("backend.apps.account_payment.webhooks.StripePaymentMethod")
+    def test_reads_card_country(self, pm_cls):
+        pm_cls.retrieve.return_value = {"card": {"country": "US"}}
+        assert _card_country("pm_123") == "US"
+        pm_cls.retrieve.assert_called_once_with("pm_123")
+
+    @patch("backend.apps.account_payment.webhooks.StripePaymentMethod")
+    def test_returns_none_without_card(self, pm_cls):
+        pm_cls.retrieve.return_value = {"card": None}
+        assert _card_country("pm_123") is None
+
+    @patch("backend.apps.account_payment.webhooks.StripePaymentMethod")
+    def test_returns_none_when_card_missing(self, pm_cls):
+        pm_cls.retrieve.return_value = {}
+        assert _card_country("pm_123") is None
+
+
+# ---------------------------------------------------------------------------
+# _regional_price_id (webhook glue)
+# ---------------------------------------------------------------------------
+
+
+class TestRegionalPriceIdGlue:
+    def test_no_payment_method_keeps_original(self):
+        assert _regional_price_id("price_br_pro_m", None, "[ctx] ") == "price_br_pro_m"
+
+    @patch("backend.apps.account_payment.webhooks._card_country")
+    def test_stripe_error_keeps_original(self, card_country):
+        card_country.side_effect = RuntimeError("stripe down")
+        assert _regional_price_id("price_br_pro_m", "pm_123", "[ctx] ") == "price_br_pro_m"
+
+    @patch("backend.apps.account_payment.webhooks.DJStripePrice")
+    @patch("backend.apps.account_payment.webhooks._card_country")
+    def test_us_card_swaps_to_intl(self, card_country, price_model):
+        card_country.return_value = "US"
+        price_model.objects.all.return_value = CATALOGUE
+        assert _regional_price_id("price_br_pro_m", "pm_123", "[ctx] ") == "price_intl_pro_m"
+
+    @patch("backend.apps.account_payment.webhooks.DJStripePrice")
+    @patch("backend.apps.account_payment.webhooks._card_country")
+    def test_br_card_keeps_brl_price(self, card_country, price_model):
+        card_country.return_value = "BR"
+        price_model.objects.all.return_value = CATALOGUE
+        assert _regional_price_id("price_br_pro_m", "pm_123", "[ctx] ") == "price_br_pro_m"
+
+    @patch("backend.apps.account_payment.webhooks.DJStripePrice")
+    @patch("backend.apps.account_payment.webhooks._card_country")
+    def test_unknown_card_country_bills_intl(self, card_country, price_model):
+        # Stripe returned no country -> intl tier, arbitrage-safe default.
+        card_country.return_value = None
+        price_model.objects.all.return_value = CATALOGUE
+        assert _regional_price_id("price_br_pro_m", "pm_123", "[ctx] ") == "price_intl_pro_m"

--- a/backend/apps/account_payment/webhooks.py
+++ b/backend/apps/account_payment/webhooks.py
@@ -14,8 +14,13 @@ from googleapiclient.discovery import Resource, build
 from googleapiclient.errors import HttpError
 from loguru import logger
 from stripe import Customer as StripeCustomer
+from stripe import PaymentMethod as StripePaymentMethod
 
 from backend.apps.account.models import Account, Subscription
+from backend.apps.account_payment.regional_pricing import (
+    country_to_region,
+    resolve_regional_price_id,
+)
 from backend.apps.account_payment.trials import (
     account_eligible_for_bdpro_stripe_trial,
     account_eligible_for_chatbot_stripe_trial,
@@ -863,6 +868,60 @@ def resume_subscription(event: Event, **kwargs):
     )
 
 
+def _card_country(payment_method_id: str) -> str | None:
+    """Return the ISO country of the card behind a Stripe PaymentMethod.
+
+    Args:
+        payment_method_id: The `pm_...` id attached to the checkout.
+
+    Returns:
+        The card's two-letter country code, or `None` if the payment method has
+        no card (e.g. a non-card method) or Stripe omits the country.
+    """
+    payment_method = StripePaymentMethod.retrieve(payment_method_id)
+    card = payment_method.get("card") or {}
+    return card.get("country")
+
+
+def _regional_price_id(original_price_id: str, payment_method, ctx: str) -> str:
+    """Swap in the region-correct price for the card's country (arbitrage guard).
+
+    Reads the country of the card attached to the checkout and, when a price for
+    that region exists for the same product and interval, returns it in place of
+    `original_price_id`. Any failure — no card on the intent, a Stripe lookup
+    error, or no regional sibling — leaves `original_price_id` untouched, so this
+    never blocks a subscription from being created.
+
+    Args:
+        original_price_id: The Stripe price id encoded in the SetupIntent.
+        payment_method: The `pm_...` id from the SetupIntent, or a falsy value.
+        ctx: Logging prefix identifying the webhook event.
+
+    Returns:
+        The Stripe price id to charge.
+    """
+    if not payment_method:
+        return original_price_id
+
+    try:
+        country = _card_country(payment_method)
+    except Exception as e:  # noqa: BLE001 — never block checkout on a Stripe/network error.
+        logger.opt(exception=e).warning(
+            f"{ctx}Could not read card country for {payment_method!r}; "
+            "charging the price as checked out."
+        )
+        return original_price_id
+
+    region = country_to_region(country)
+    chosen = resolve_regional_price_id(DJStripePrice.objects.all(), original_price_id, region)
+    if chosen != original_price_id:
+        logger.info(
+            f"{ctx}Card country {country!r} maps to region {region!r}; "
+            f"charging {chosen} instead of {original_price_id}."
+        )
+    return chosen
+
+
 @webhooks.handler("setup_intent.succeeded")
 def setup_intent_succeeded(event: Event, **kwargs):
     """Finish checkout: save the payment method and start the subscription.
@@ -908,6 +967,13 @@ def setup_intent_succeeded(event: Event, **kwargs):
 
     if not price_id:
         return
+
+    # Arbitrage guard: charge in the currency of the card's country, not the
+    # currency of the storefront the customer happened to check out from. Swaps
+    # to the region-matching price when one exists, and keeps the original on any
+    # uncertainty (see _regional_price_id). The product type is preserved, so the
+    # chatbot/bd_pro logic below is unaffected by the swap.
+    price_id = _regional_price_id(price_id, payment_method, ctx)
 
     is_chatbot_price = _price_is_chatbot(price_id)
     if is_chatbot_price is None:


### PR DESCRIPTION
## What

Adds the server-side guardrail for region-aware pricing: BD Pro and the Chatbot sell in BRL for Brazilian cards, and in USD at a Latin-America tier and an international tier for everyone else. The storefront picks the price to **show** by domain (website PR `feat/regional-price-display`); this picks the price to **charge**, from the country of the card the customer actually used — so switching to a cheaper regional domain does not change what they pay.

## Changes

- **`regional_pricing.py`** (new) — pure, DB-free logic:
  - `country_to_region(iso)` → `br` / `latam` / `intl`.
  - `resolve_regional_price_id(prices, id, region)` finds the region-matching price for the same product `code` and interval, **falling back to the original price on any uncertainty** (not found, already matching, no active sibling) so a subscription is never blocked.
- **`webhooks.py` `setup_intent.succeeded`** — reads the card country from the attached payment method and swaps in the regional price before `customer.subscribe`. Any Stripe/network error keeps the checked-out price. Product type and trial logic are unaffected (the swap preserves the product `code`).
- **`graphql.py` `StripePriceNode.region`** — exposes the price's `region` metadata so the storefront can select the right currency by domain.

## Scope

Enforcement covers the **trial / SetupIntent path**, where the card is known at subscribe time. The non-trial `default_incomplete` path has no card yet and is a follow-up.

## Tests

- Pure logic (`country_to_region`, `resolve_regional_price_id`) is unit-tested and passes standalone (14/14).
- The webhook glue (`_card_country`, `_regional_price_id`) is mock-tested — no live Stripe or DB.

## Deploy note

Ship **together with** the website `feat/regional-price-display` PR. Enforcing here while the site still shows only BRL would show R$ but charge US$. The website degrades safely to BRL, so website-first or simultaneous is fine; backend-enforcement-first is not.

## Assumption

The regional sibling is matched by product `code` (`bd_pro` / `chatbot`) + interval + `region` metadata. The USD prices must carry the same `code` as their BRL counterparts (same product or separate — only the `code` needs to match) and a `region` tag.
