### PR TITLE
fix(account): return Google OAuth to the originating frontend domain

### DIFF
--- a/backend/apps/account/views.py
+++ b/backend/apps/account/views.py
@@ -22,7 +22,19 @@ from loguru import logger
 
 from backend.apps.account.signals import send_activation_email
 from backend.apps.account.token import token_generator
-from backend.custom.environment import get_frontend_url
+from backend.custom.environment import get_allowed_frontend_origins, get_frontend_url
+
+
+def _safe_frontend_origin(candidate):
+    """Return `candidate` only if it is an allowed frontend origin, else None.
+
+    Guards the Google OAuth redirect against open-redirect abuse: the success
+    URL carries a JWT, so the target origin must be on the per-environment
+    allowlist before it is trusted.
+    """
+    if candidate and candidate in get_allowed_frontend_origins():
+        return candidate
+    return None
 
 
 class AccountActivateView(View):
@@ -157,6 +169,16 @@ class GoogleAuthView(View):
             state = secrets.token_urlsafe(32)
             request.session["oauth_state"] = state
 
+            # Remember which frontend domain the login started on, so the
+            # callback returns the user there (pt/en/es live on sibling
+            # domains). Validated against the allowlist; unknown values are
+            # dropped and the callback falls back to settings.FRONTEND_URL.
+            redirect_origin = _safe_frontend_origin(request.GET.get("redirect_origin"))
+            if redirect_origin:
+                request.session["frontend_origin"] = redirect_origin
+            else:
+                request.session.pop("frontend_origin", None)
+
             auth_url = (
                 "https://accounts.google.com/o/oauth2/v2/auth?"
                 f"client_id={settings.GOOGLE_OAUTH_CLIENT_ID}&"
@@ -202,27 +224,37 @@ class GoogleCallbackView(View):
             if "oauth_state" in request.session:
                 del request.session["oauth_state"]
 
+            # Return the user to the domain they logged in from (set in
+            # GoogleAuthView); fall back to the static frontend if absent or
+            # no longer allowlisted.
+            frontend_base = (
+                _safe_frontend_origin(request.session.pop("frontend_origin", None))
+                or settings.FRONTEND_URL
+            )
+
             token_data = self._exchange_code_for_token(auth_code)
             if not token_data:
                 logger.error("Falha ao trocar código por token")
-                error_url = f"{settings.FRONTEND_URL}/user/login?error=auth_failed"
+                error_url = f"{frontend_base}/user/login?error=auth_failed"
                 return HttpResponseRedirect(error_url)
 
             user_info = self._get_user_info(token_data["access_token"])
             if not user_info:
                 logger.error("Não foi possível obter informações do usuário")
-                error_url = f"{settings.FRONTEND_URL}/user/login?error=user_info_failed"
+                error_url = f"{frontend_base}/user/login?error=user_info_failed"
                 return HttpResponseRedirect(error_url)
 
             account = self._create_or_update_account(user_info, token_data.get("id_token"))
 
             if account:
                 jwt_token = get_token(account)
-                frontend_url = f"{settings.FRONTEND_URL}/user/login?login=success&token={jwt_token}&id={account.id}"  # noqa: E501
+                frontend_url = (
+                    f"{frontend_base}/user/login?login=success&token={jwt_token}&id={account.id}"  # noqa: E501
+                )
                 return HttpResponseRedirect(frontend_url)
             else:
                 logger.error("Erro ao criar/atualizar conta")
-                error_url = f"{settings.FRONTEND_URL}/user/login?error=account_creation_failed"
+                error_url = f"{frontend_base}/user/login?error=account_creation_failed"
                 return HttpResponseRedirect(error_url)
 
         except Exception as e:

--- a/backend/custom/environment.py
+++ b/backend/custom/environment.py
@@ -58,6 +58,31 @@ def get_frontend_url():
     return "localhost:3000"
 
 
+# The three sibling frontends, one locale per domain (see the website's
+# next-i18next.config.js): pt -> basedosdados.org, en -> data-basis.org,
+# es -> basedelosdatos.org.
+FRONTEND_DOMAINS = ("basedosdados.org", "data-basis.org", "basedelosdatos.org")
+
+
+def get_allowed_frontend_origins():
+    """Allowed post-login redirect origins (scheme + host), by environment.
+
+    Google OAuth must return the user to the same domain they started on. The
+    callback picks the redirect target from this allowlist using the
+    `redirect_origin` the login page sends; anything off the list falls back to
+    the single static FRONTEND_URL. The allowlist is what makes honoring an
+    arbitrary redirect origin safe (a JWT rides in the redirect URL, so an
+    unvalidated origin would be an open redirect that leaks tokens).
+    """
+    if is_prd():
+        return {f"https://{d}" for d in FRONTEND_DOMAINS}
+    if is_stg():
+        return {f"https://staging.{d}" for d in FRONTEND_DOMAINS}
+    if is_dev():
+        return {f"https://development.{d}" for d in FRONTEND_DOMAINS}
+    return {"http://localhost:3000"}
+
+
 def production_task(func):
     """Decorator that avoids function call if it isn't production"""
 


### PR DESCRIPTION
## Problem
Signing in with **Google** always returned the user to the static `settings.FRONTEND_URL` (the Portuguese domain). A login started on `data-basis.org` (en) or `basedelosdatos.org` (es) therefore landed on `basedosdados.org`, and — because the frontend's `previousPath` return address lives in the *originating* domain's `localStorage` — the user fell through to the site root instead of back to `/chatbot`.

## Fix
- `GoogleAuthView` reads a `redirect_origin` query param (the login page now sends `window.location.origin`), validates it against a per-environment allowlist, and stashes it in the session next to the existing `oauth_state`.
- `GoogleCallbackView` returns the user to that origin for **every** redirect (success + all error branches), falling back to `settings.FRONTEND_URL` when absent or not allowlisted.
- New `get_allowed_frontend_origins()` in `custom/environment.py` returns the three sibling domains for the active environment.

## Security
The success URL carries a JWT, so honoring an arbitrary origin would be a token-leaking open redirect. The allowlist is the guard: any origin not on it is ignored and the static fallback is used.

## Deploy note
Order-independent with the website change: if this ships first, the callback simply keeps using `FRONTEND_URL` until the site starts sending `redirect_origin`; no regression either way.

## Testing
- `python -m py_compile` on both files; `ruff check`/`ruff format` clean (pre-commit).
- Manual: reproduced the pt-domain bounce on staging; the allowlisted-origin round-trip returns to the originating domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
