### PR TITLE
refactor(account): remove legacy Career.team_old and role_old fields

### DIFF
--- a/backend/apps/account/admin.py
+++ b/backend/apps/account/admin.py
@@ -342,9 +342,7 @@ class RoleAdmin(admin.ModelAdmin):
 class CareerAdmin(admin.ModelAdmin):
     list_display = (
         "account",
-        "team_old",
         "team",
-        "role_old",
         "role",
         "level",
         "start_at",
@@ -352,9 +350,7 @@ class CareerAdmin(admin.ModelAdmin):
     )
     search_fields = (
         "account__email",
-        "team_old",
         "team__name",
-        "role_old",
         "role__name",
     )
     readonly_fields = ("created_at", "updated_at")

--- a/backend/apps/account/migrations/0029_remove_career_team_old_remove_career_role_old.py
+++ b/backend/apps/account/migrations/0029_remove_career_team_old_remove_career_role_old.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("account", "0028_alter_account_uuid"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="career",
+            name="team_old",
+        ),
+        migrations.RemoveField(
+            model_name="career",
+            name="role_old",
+        ),
+    ]

--- a/backend/apps/account/models.py
+++ b/backend/apps/account/models.py
@@ -495,11 +495,9 @@ class Role(BaseModel):
 class Career(BaseModel):
     id = models.UUIDField(primary_key=True, default=uuid4)
     account = models.ForeignKey(Account, on_delete=models.DO_NOTHING, related_name="careers")
-    team_old = models.CharField("Team (old)", max_length=40, blank=True)
     team = models.ForeignKey(
         Team, on_delete=models.DO_NOTHING, related_name="careers", null=True, blank=True
     )
-    role_old = models.CharField("Role (old)", max_length=40, blank=True)
     role = models.ForeignKey(
         Role, on_delete=models.DO_NOTHING, related_name="careers", null=True, blank=True
     )


### PR DESCRIPTION
## What

Remove the legacy `Career.team_old` ("Team (old)") and `Career.role_old` ("Role (old)") CharFields, superseded by the `team` and `role` foreign keys.

- Drop both fields from `Career` (`backend/apps/account/models.py`).
- Remove their `list_display` / `search_fields` entries in `CareerAdmin` (`admin.py`).
- Migration `0029_remove_career_team_old_remove_career_role_old` drops the two columns.

## Notes

- The fields were referenced only in the model and admin — no GraphQL, serializer, or test usage.
- Validated locally with `manage.py makemigrations account --check` → "No changes detected in app 'account'".
- ⚠️ Applying this migration drops the two columns (and any remaining data in them). Deploy accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
