### PR TITLE
feat: email end trial

### DIFF
--- a/backend/apps/account/templates/account/activation_email.html
+++ b/backend/apps/account/templates/account/activation_email.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html lang="pt-BR">
 
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
 </head>
 
 <body style="
@@ -11,48 +14,48 @@
   margin: 0 auto;
   width: 100%;
   max-width: 600px;
+  font-family: 'Roboto', Arial, sans-serif;
   padding: 0 28px;
   box-sizing: content-box;
 ">
-  <a href="https://basedosdados.org" target="_blank" style="display: flex; width: 100%;">
-    <img alt="logo" style="width: 75px; margin: 0 auto;" src="https://basedosdados.github.io/mais/images/bd_minilogo.png">
+  <a href="https://basedosdados.org" target="_blank" style="display: block; width: 100%; margin: 20px 0; text-align: center;">
+    <img alt="logo" style="width: 100px; height: auto; display: inline-block; border: 0;" src="https://basedosdados.org/img/logo.png">
   </a>
 
-  <h1 style="width: 100%; padding-top: 32px; margin: 0 0 16px; border-top: 1px solid #DEDFE0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 700; line-height: 24px;">Olá, {{ name }}</h1>
+  <h1 style="width: 100%; padding-top: 32px; margin: 0 0 16px; border-top: 1px solid #DEDFE0; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 18px; font-style: normal; font-weight: 500; line-height: 28px;">Olá, {{ name }}</h1>
 
   <div style="display: block; width: 100%; margin: 16px 0;">
-    <p style="width: 100%; margin: 0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 400; line-height: 22px; margin-bottom: 8px;">Informamos que o seu cadastro na Base dos Dados foi realizado com sucesso!</p>
-    <p style="width: 100%; margin: 0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 400; line-height: 22px;">Para começar a aproveitar todos os benefícios da nossa plataforma, clique no botão abaixo para verificar o seu e-mail e concluir o cadastro:</p>
+    <p style="width: 100%; margin: 0 0 8px; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-style: normal; font-weight: 400; line-height: 24px;">Informamos que o seu cadastro na Base dos Dados foi realizado com sucesso!</p>
+    <p style="width: 100%; margin: 0; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-style: normal; font-weight: 400; line-height: 24px;">Para começar a aproveitar todos os benefícios da nossa plataforma, clique no botão abaixo para verificar o seu e-mail e concluir o cadastro:</p>
   </div>
 
-  <a
-    href="https://{{ domain }}/user/activate-account?q={{ uid }}&p={{ token }}"
-    style="
-      color: #FFF;
-      background-color: #42B0FF;
-      border-radius: 30px;
-      text-decoration: none;
-      display: block;
-      text-align: center;
-      width: 160px;
-      padding: 8px 16px;
-      margin: 0 auto;
-      font-size: 14px;
-      font-weight: 700;
-      line-height: 24px;
-      letter-spacing: 0.2px;
-      font-family: Arial;
-    ">Verificar meu e-mail</a>
+  <div style="display: block; width: 100%; text-align: center; margin: 24px 0;">
+    <a
+      href="https://{{ domain }}/user/activate-account?q={{ uid }}&p={{ token }}"
+      style="
+        display: inline-block;
+        color: #FFF;
+        background-color: #2B8C4D;
+        border-radius: 8px;
+        text-decoration: none;
+        text-align: center;
+        padding: 10px 20px;
+        font-size: 14px;
+        font-weight: 500;
+        line-height: 20px;
+        font-family: 'Roboto', Arial, sans-serif;
+      ">Verificar meu e-mail</a>
+  </div>
 
   <span style="display: block; width: 100%; margin: 32px 0; border-top: 1px solid #DEDFE0;"></span>
 
-  <p style="color: #6F6F6F; text-align: center; font-family: Arial; font-size: 13px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; margin: 0;">Se você não realizou o cadastro em nossa plataforma, pedimos que desconsidere este comunicado. Não é necessário realizar nenhuma ação adicional.</p>
+  <p style="color: #6F6F6F; text-align: center; font-family: 'Roboto', Arial, sans-serif; font-size: 14px; font-weight: 400; line-height: 20px; margin: 0;">Se você não realizou o cadastro em nossa plataforma, pedimos que desconsidere este comunicado. Não é necessário realizar nenhuma ação adicional.</p>
 
   <span style="display: block; width: 100%; margin: 32px 0; border-top: 1px solid #DEDFE0;"></span>
 
   <div style="display: block; width: 100%; margin: 0 auto;">
-    <p style="text-align: center; color: #A3A3A3; font-family: Arial; font-size: 12px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; margin: 0;">Esta mensagem foi enviada pela</p>
-    <p style="text-align: center; color: #A3A3A3; font-family: Arial; font-size: 12px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; text-decoration: none; margin: 0;">Base dos Dados</p>
+    <p style="text-align: center; color: #A3A3A3; font-family: 'Roboto', Arial, sans-serif; font-size: 12px; font-weight: 400; line-height: 18px; margin: 0;">Esta mensagem foi enviada pela</p>
+    <p style="text-align: center; color: #A3A3A3; font-family: 'Roboto', Arial, sans-serif; font-size: 12px; font-weight: 400; line-height: 18px; text-decoration: none; margin: 0;">Base dos Dados</p>
   </div>
 
   <style>

--- a/backend/apps/account/templates/account/creation_bd_pro.html
+++ b/backend/apps/account/templates/account/creation_bd_pro.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html lang="pt-BR">
 
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
 </head>
 
 <body style="
@@ -11,49 +14,49 @@
   margin: 0 auto;
   width: 100%;
   max-width: 600px;
+  font-family: 'Roboto', Arial, sans-serif;
   padding: 0 28px;
   box-sizing: content-box;
 ">
-  <a href="https://basedosdados.org" target="_blank" style="display: flex; width: 100%;">
-    <img alt="logo" style="width: 75px; margin: 0 auto;" src="https://basedosdados.github.io/mais/images/bd_minilogo.png">
+  <a href="https://basedosdados.org" target="_blank" style="display: block; width: 100%; margin: 20px 0; text-align: center;">
+    <img alt="logo" style="width: 100px; height: auto; display: inline-block; border: 0;" src="https://basedosdados.org/img/logo.png">
   </a>
 
-  <h1 style="width: 100%; padding-top: 32px; margin: 0 0 16px; border-top: 1px solid #DEDFE0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 700; line-height: 24px;">Olá, {{ name }}</h1>
+  <h1 style="width: 100%; padding-top: 32px; margin: 0 0 16px; border-top: 1px solid #DEDFE0; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 18px; font-style: normal; font-weight: 500; line-height: 28px;">Olá, {{ name }}</h1>
 
   <div style="display: block; width: 100%; margin: 16px 0;">
-    <p style="width: 100%; margin: 0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 400; line-height: 22px; margin-bottom: 8px;">Obrigado por assinar nosso produto! Ficamos felizes em informar que uma conta já foi criada para você em nossa plataforma.</p>
-    <p style="width: 100%; margin: 0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 400; line-height: 22px; margin-bottom: 8px;">Utilizando o seu email e nome de usuário associados à assinatura.</p>
-    <p style="width: 100%; margin: 0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 400; line-height: 22px;">Para acessar sua conta, basta definir uma senha.</p>
+    <p style="width: 100%; margin: 0 0 8px; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-style: normal; font-weight: 400; line-height: 24px;">Obrigado por assinar nosso produto! Ficamos felizes em informar que uma conta já foi criada para você em nossa plataforma.</p>
+    <p style="width: 100%; margin: 0 0 8px; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-style: normal; font-weight: 400; line-height: 24px;">Utilizando o seu email e nome de usuário associados à assinatura.</p>
+    <p style="width: 100%; margin: 0; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-style: normal; font-weight: 400; line-height: 24px;">Para acessar sua conta, basta definir uma senha.</p>
   </div>
 
-  <a
-    href="http://{{ domain }}/reset_password/{{ uid }}/{{ token }}/"
-    style="
-      color: #FFF;
-      background-color: #42B0FF;
-      border-radius: 30px;
-      text-decoration: none;
-      display: block;
-      text-align: center;
-      width: 160px;
-      padding: 8px 16px;
-      margin: 0 auto;
-      font-size: 14px;
-      font-weight: 700;
-      line-height: 24px;
-      letter-spacing: 0.2px;
-      font-family: Arial;
-    ">Definir Senha</a>
+  <div style="display: block; width: 100%; text-align: center; margin: 24px 0;">
+    <a
+      href="http://{{ domain }}/reset_password/{{ uid }}/{{ token }}/"
+      style="
+        display: inline-block;
+        color: #FFF;
+        background-color: #2B8C4D;
+        border-radius: 8px;
+        text-decoration: none;
+        text-align: center;
+        padding: 10px 20px;
+        font-size: 14px;
+        font-weight: 500;
+        line-height: 20px;
+        font-family: 'Roboto', Arial, sans-serif;
+      ">Definir Senha</a>
+  </div>
 
   <span style="display: block; width: 100%; margin: 32px 0; border-top: 1px solid #DEDFE0;"></span>
 
-  <p style="color: #6F6F6F; text-align: center; font-family: Arial; font-size: 13px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; margin: 0;">Se você tiver alguma dúvida ou precisar de assistência, não hesite em nos contatar. Estamos aqui para ajudar!</p>
+  <p style="color: #6F6F6F; text-align: center; font-family: 'Roboto', Arial, sans-serif; font-size: 14px; font-weight: 400; line-height: 20px; margin: 0;">Se você tiver alguma dúvida ou precisar de assistência, não hesite em nos contatar. Estamos aqui para ajudar!</p>
 
   <span style="display: block; width: 100%; margin: 32px 0; border-top: 1px solid #DEDFE0;"></span>
 
   <div style="display: block; width: 100%; margin: 0 auto;">
-    <p style="text-align: center; color: #A3A3A3; font-family: Arial; font-size: 12px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; margin: 0;">Esta mensagem foi enviada pela</p>
-    <p style="text-align: center; color: #A3A3A3; font-family: Arial; font-size: 12px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; text-decoration: none; margin: 0;">Base dos Dados</p>
+    <p style="text-align: center; color: #A3A3A3; font-family: 'Roboto', Arial, sans-serif; font-size: 12px; font-weight: 400; line-height: 18px; margin: 0;">Esta mensagem foi enviada pela</p>
+    <p style="text-align: center; color: #A3A3A3; font-family: 'Roboto', Arial, sans-serif; font-size: 12px; font-weight: 400; line-height: 18px; text-decoration: none; margin: 0;">Base dos Dados</p>
   </div>
 
   <style>

--- a/backend/apps/account/templates/account/end_trial_chatbot.html
+++ b/backend/apps/account/templates/account/end_trial_chatbot.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+</head>
+
+<body style="
+  display: block;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 600px;
+  font-family: 'Roboto', Arial, sans-serif;
+  padding: 0 28px;
+  box-sizing: content-box;
+">
+  <a href="https://basedosdados.org" target="_blank" style="display: block; width: 100%; margin: 20px 0; text-align: center;">
+    <img alt="logo" style="width: 100px; height: auto; display: inline-block; border: 0;" src="https://basedosdados.org/img/logo.png">
+  </a>
+
+  <h1 style="width: 100%; padding-top: 32px; margin: 0 0 16px; border-top: 1px solid #DEDFE0; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 18px; font-style: normal; font-weight: 500; line-height: 28px;">Olá, {{ name }}!</h1>
+
+  <div style="display: block; width: 100%; margin: 16px 0;">
+    <p style="width: 100%; margin: 0 0 8px; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-style: normal; font-weight: 400; line-height: 24px;">Seus 7 dias de acesso gratuito ao chatbot da Base dos Dados terminaram. Esperamos que ele tenha te ajudado a encontrar dados, otimizar suas análises e responder suas dúvidas com rapidez.</p>
+    <p style="width: 100%; margin: 0; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-style: normal; font-weight: 400; line-height: 24px;">A boa notícia é que você não precisa parar por aqui! Para continuar contando com a nossa inteligência para navegar pelo universo dos dados, basta fazer uma assinatura.</p>
+  </div>
+
+  <div style="display: block; width: 100%; margin: 24px 0 16px;">
+    <p style="width: 100%; margin: 0 0 12px; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-style: normal; font-weight: 500; line-height: 24px;">Por que assinar?</p>
+    <ul style="width: 100%; padding-left: 20px; margin: 0; color: #252A32;">
+      <li style="margin-bottom: 8px; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-weight: 400; line-height: 24px;"><strong style="font-weight: 500;">Respostas ilimitadas:</strong> faça perguntas sobre centenas de tabelas disponíveis na nossa plataforma sem restrição.</li>
+      <li style="margin-bottom: 8px; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-weight: 400; line-height: 24px;"><strong style="font-weight: 500;">Economia de tempo:</strong> esqueça as buscas manuais e gere insights para a sua análise em segundos.</li>
+      <li style="margin-bottom: 0; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-weight: 400; line-height: 24px;"><strong style="font-weight: 500;">Apoio a dados abertos:</strong> você ajuda a manter a infraestrutura da BD viva e acessível para toda a comunidade.</li>
+    </ul>
+  </div>
+
+  <div style="display: block; width: 100%; text-align: center; margin: 24px 0;">
+    <a
+      href="https://{{ domain }}/chatbot"
+      style="
+        display: inline-block;
+        color: #FFF;
+        background-color: #2B8C4D;
+        border-radius: 8px;
+        text-decoration: none;
+        text-align: center;
+        padding: 10px 20px;
+        font-size: 14px;
+        font-weight: 500;
+        line-height: 20px;
+        font-family: 'Roboto', Arial, sans-serif;
+      ">Quero continuar usando o chatbot</a>
+  </div>
+
+  <span style="display: block; width: 100%; margin: 32px 0; border-top: 1px solid #DEDFE0;"></span>
+
+  <p style="color: #6F6F6F; text-align: center; font-family: 'Roboto', Arial, sans-serif; font-size: 14px; font-weight: 400; line-height: 20px; margin: 0;">Se você tiver qualquer dúvida ou feedback sobre o chatbot, basta entrar em contato com nossa equipe.</p>
+
+  <span style="display: block; width: 100%; margin: 32px 0; border-top: 1px solid #DEDFE0;"></span>
+
+  <div style="display: block; width: 100%; margin: 0 auto;">
+    <p style="text-align: center; color: #A3A3A3; font-family: 'Roboto', Arial, sans-serif; font-size: 12px; font-weight: 400; line-height: 18px; margin: 0;">Esta mensagem foi enviada pela</p>
+    <p style="text-align: center; color: #A3A3A3; font-family: 'Roboto', Arial, sans-serif; font-size: 12px; font-weight: 400; line-height: 18px; text-decoration: none; margin: 0;">Base dos Dados</p>
+  </div>
+
+  <style>
+    @media (max-width: 600px) {
+      body {
+        max-width: 100%;
+        padding: 0 28px;
+      }
+    }
+  </style>
+</body>
+
+</html>

--- a/backend/apps/account/templates/account/password_reset_email.html
+++ b/backend/apps/account/templates/account/password_reset_email.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html lang="pt-BR">
 
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
 </head>
 
 <body style="
@@ -11,48 +14,47 @@
   margin: 0 auto;
   width: 100%;
   max-width: 600px;
-  font-family: 'Lato',sans-serif;
+  font-family: 'Roboto', Arial, sans-serif;
   padding: 0 28px;
   box-sizing: content-box;
 ">
 
-  <a href="https://basedosdados.org" target="_blank" style="display: flex; width: 100%;">
-    <img alt="logo" style="width: 75px; margin: 0 auto;" src="https://basedosdados.github.io/mais/images/bd_minilogo.png">
+  <a href="https://basedosdados.org" target="_blank" style="display: block; width: 100%; margin: 20px 0; text-align: center;">
+    <img alt="logo" style="width: 100px; height: auto; display: inline-block; border: 0;" src="https://basedosdados.org/img/logo.png">
   </a>
 
-  <h1 style="width: 100%; padding-top: 32px; margin: 0 0 16px; border-top: 1px solid #DEDFE0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 700; line-height: 24px;">Olá, {{ name }}</h1>
+  <h1 style="width: 100%; padding-top: 32px; margin: 0 0 16px; border-top: 1px solid #DEDFE0; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 18px; font-style: normal; font-weight: 500; line-height: 28px;">Olá, {{ name }}</h1>
 
   <div style="display: block; width: 100%; margin: 16px 0;">
-    <p style="width: 100%; margin: 0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 400; line-height: 22px; margin-bottom: 8px;">Recebemos uma solicitação de redefinição de senha para a sua conta na Base dos Dados.</p>
-    <p style="width: 100%; margin: 0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 400; line-height: 22px;">Para criar uma nova senha, clique no botão abaixo:</p>
+    <p style="width: 100%; margin: 0 0 8px; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-style: normal; font-weight: 400; line-height: 24px;">Recebemos uma solicitação de redefinição de senha para a sua conta na Base dos Dados.</p>
+    <p style="width: 100%; margin: 0; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-style: normal; font-weight: 400; line-height: 24px;">Para criar uma nova senha, clique no botão abaixo:</p>
   </div>
 
-  <a
-    href="https://{{ domain }}/user/password-recovery?q={{ uid }}&p={{ token }}"
-    style="
-      color: #FFF;
-      background-color: #42B0FF;
-      border-radius: 30px;
-      text-decoration: none;
-      display: block;
-      text-align: center;
-      width: 160px;
-      padding: 8px 16px;
-      margin: 0 auto;
-      font-size: 14px;
-      font-weight: 700;
-      line-height: 24px;
-      letter-spacing: 0.2px;
-      font-family: Arial;
-  ">Redefinir minha senha</a>
+  <div style="display: block; width: 100%; text-align: center; margin: 24px 0;">
+    <a
+      href="https://{{ domain }}/user/password-recovery?q={{ uid }}&p={{ token }}"
+      style="
+        display: inline-block;
+        color: #FFF;
+        background-color: #2B8C4D;
+        border-radius: 8px;
+        text-decoration: none;
+        text-align: center;
+        padding: 10px 20px;
+        font-size: 14px;
+        font-weight: 500;
+        line-height: 20px;
+        font-family: 'Roboto', Arial, sans-serif;
+    ">Redefinir minha senha</a>
+  </div>
 
   <span style="display: block; width: 100%; margin: 32px 0; border-top: 1px solid #DEDFE0;"></span>
 
   <div style="display: block; width: 100%; margin: 0 auto;">
-    <p style="color: #6F6F6F; text-align: center; font-family: Arial; font-size: 13px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; margin: 0;">
+    <p style="color: #6F6F6F; text-align: center; font-family: 'Roboto', Arial, sans-serif; font-size: 14px; font-weight: 400; line-height: 20px; margin: 0;">
       Se você não fez essa solicitação, ignore este e-mail. A sua senha atual continuará válida e segura. Caso tenha alguma dúvida ou precise de suporte, entre em contato através do e-mail
     </p>
-    <p style="width: 100%; text-align: center; color: #6F6F6F; margin: 0; font-family: Arial; font-size: 13px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; margin: 0; text-decoration: none;">
+    <p style="width: 100%; text-align: center; color: #6F6F6F; margin: 0; font-family: 'Roboto', Arial, sans-serif; font-size: 14px; font-weight: 400; line-height: 20px; text-decoration: none;">
       contato@basedosdados.org
     </p>
   </div>
@@ -60,8 +62,8 @@
   <span style="display: block; width: 100%; margin: 32px 0; border-top: 1px solid #DEDFE0;"></span>
 
   <div style="display: block; width: 100%; margin: 0 auto;">
-    <p style="text-align: center; color: #A3A3A3; font-family: Arial; font-size: 12px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; margin: 0;">Esta mensagem foi enviada pela</p>
-    <p style="text-align: center; color: #A3A3A3; font-family: Arial; font-size: 12px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; text-decoration: none; margin: 0;">Base dos Dados</p>
+    <p style="text-align: center; color: #A3A3A3; font-family: 'Roboto', Arial, sans-serif; font-size: 12px; font-weight: 400; line-height: 18px; margin: 0;">Esta mensagem foi enviada pela</p>
+    <p style="text-align: center; color: #A3A3A3; font-family: 'Roboto', Arial, sans-serif; font-size: 12px; font-weight: 400; line-height: 18px; text-decoration: none; margin: 0;">Base dos Dados</p>
   </div>
 
   <style>

--- a/backend/apps/account_payment/graphql.py
+++ b/backend/apps/account_payment/graphql.py
@@ -400,7 +400,17 @@ class StripeCouponValidationMutation(Mutation):
 
 
 class StripeSubscriptionDeleteMutation(Mutation):
-    """Delete stripe subscription"""
+    """Schedule stripe subscription cancellation for the end of the current period.
+
+    Uses the Stripe update endpoint (`cancel_at_period_end=True`) directly
+    instead of djstripe's `Subscription.cancel()` helper: that helper
+    silently overrides `at_period_end` to `False` whenever the subscription
+    is still trialing (to avoid an unexpected charge), which cancels the
+    subscription immediately and revokes access mid-trial. Scheduling via
+    `cancel_at_period_end` doesn't trigger a charge either way, so the
+    override isn't needed here and access is kept until the trial/period
+    actually ends.
+    """
 
     subscription = Field(StripeSubscriptionNode)
     errors = List(String)
@@ -414,7 +424,10 @@ class StripeSubscriptionDeleteMutation(Mutation):
         try:
             subscription = Subscription.objects.get(id=subscription_id)
             stripe_subscription = subscription.subscription
-            stripe_subscription.cancel(at_period_end=True)
+            updated = stripe_subscription._api_update(cancel_at_period_end=True)
+            DJStripeSubscription.sync_from_stripe_data(
+                updated, api_key=stripe_subscription.default_api_key
+            )
             return None
         except Exception as e:
             logger.error(e)

--- a/backend/apps/account_payment/webhooks.py
+++ b/backend/apps/account_payment/webhooks.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 from typing import NamedTuple
 
 from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
 from django.db.models import Q
+from django.template.loader import render_to_string
 from djstripe import webhooks
 from djstripe.models import Event
 from djstripe.models import Price as DJStripePrice
@@ -23,7 +25,7 @@ from backend.apps.account_payment.trials import (
     djstripe_subscription_is_chatbot,
 )
 from backend.custom.client import send_discord_message as send
-from backend.custom.environment import get_backend_url, is_dev, is_stg
+from backend.custom.environment import get_backend_url, get_frontend_url, is_dev, is_stg
 
 logger = logger.bind(module="payment")
 
@@ -511,6 +513,41 @@ def remove_user(email: str, group_key: str = None, event_context: str = None) ->
         raise
 
 
+def send_chatbot_trial_ended_email(account: Account, event_context: str = None) -> None:
+    """Send the "your chatbot trial ended" email.
+
+    Best-effort: logs and swallows any error instead of failing the webhook,
+    since the entitlement revocation that triggers this must still succeed
+    even if the email can't be sent.
+
+    Args:
+        account: The account whose chatbot trial just ended.
+        event_context: Human-readable context prefixed to log messages.
+    """
+    ctx = f"[{event_context}] " if event_context else ""
+    if not account or not account.email:
+        return
+    try:
+        content = render_to_string(
+            "account/end_trial_chatbot.html",
+            {
+                "name": account.get_full_name(),
+                "domain": get_frontend_url(),
+            },
+        )
+        msg = EmailMultiAlternatives(
+            "Seu período de teste do chatbot chegou ao fim. Vamos continuar?",
+            "",
+            settings.EMAIL_HOST_USER,
+            [account.email],
+        )
+        msg.attach_alternative(content, "text/html")
+        msg.send()
+        logger.info(f"{ctx}E-mail de fim de trial do chatbot enviado para {account.email}")
+    except Exception as e:
+        logger.error(f"{ctx}Erro ao enviar e-mail de fim de trial do chatbot para {account.email}: {e}")
+
+
 def apply_active_subscription_entitlements(
     wc: WebhookContext,
     subscription: Subscription | None,
@@ -725,6 +762,7 @@ def handle_subscription(event: Event):
     account = get_account_for_stripe_customer(event)
 
     status = event.data.get("object", {}).get("status")
+    previous_status = event.data.get("previous_attributes", {}).get("status")
 
     if status in ["trialing", "active"]:
         if subscription:
@@ -751,7 +789,18 @@ def handle_subscription(event: Event):
             subscription.is_active = False
             subscription.save()
 
+        trial_just_ended = previous_status == "trialing" and account
+        had_chatbot_access = bool(account and account.has_chatbot_access)
+
         apply_inactive_subscription_entitlements(wc, subscription, account)
+
+        if (
+            trial_just_ended
+            and had_chatbot_access
+            and not account.has_chatbot_access
+            and subscription_product_is_chatbot(subscription, wc.event, wc.event_context)
+        ):
+            send_chatbot_trial_ended_email(account, event_context=wc.event_context)
 
 
 @webhooks.handler("customer.subscription.updated")

--- a/backend/apps/account_payment/webhooks.py
+++ b/backend/apps/account_payment/webhooks.py
@@ -513,6 +513,38 @@ def remove_user(email: str, group_key: str = None, event_context: str = None) ->
         raise
 
 
+def chatbot_trial_just_ended(event: Event) -> bool:
+    """True if the subscription ended while it was still in trial."""
+    data = event.data or {}
+    previous_status = (data.get("previous_attributes") or {}).get("status")
+    if previous_status == "trialing":
+        return True
+
+    obj = data.get("object") or {}
+    trial_end = obj.get("trial_end")
+    ended_at = obj.get("canceled_at") or obj.get("ended_at")
+    if not trial_end or not ended_at:
+        return False
+    return int(ended_at) <= int(trial_end) + 3600
+
+
+def maybe_send_chatbot_trial_ended_email(
+    wc: WebhookContext,
+    subscription: Subscription | None,
+    account: Account | None,
+    *,
+    had_chatbot_access: bool,
+) -> None:
+    """Send the trial-ended email if chatbot access was just revoked for a trial."""
+    if not account or not chatbot_trial_just_ended(wc.event):
+        return
+    if not had_chatbot_access or account.has_chatbot_access:
+        return
+    if not subscription_product_is_chatbot(subscription, wc.event, wc.event_context):
+        return
+    send_chatbot_trial_ended_email(account, event_context=wc.event_context)
+
+
 def send_chatbot_trial_ended_email(account: Account, event_context: str = None) -> None:
     """Send the "your chatbot trial ended" email.
 
@@ -763,8 +795,7 @@ def handle_subscription(event: Event):
     subscription = get_subscription(event, event_context=wc.event_context)
     account = get_account_for_stripe_customer(event)
 
-    status = event.data.get("object", {}).get("status")
-    previous_status = event.data.get("previous_attributes", {}).get("status")
+    status = (event.data.get("object") or {}).get("status")
 
     if status in ["trialing", "active"]:
         if subscription:
@@ -791,18 +822,11 @@ def handle_subscription(event: Event):
             subscription.is_active = False
             subscription.save()
 
-        trial_just_ended = previous_status == "trialing" and account
         had_chatbot_access = bool(account and account.has_chatbot_access)
-
         apply_inactive_subscription_entitlements(wc, subscription, account)
-
-        if (
-            trial_just_ended
-            and had_chatbot_access
-            and not account.has_chatbot_access
-            and subscription_product_is_chatbot(subscription, wc.event, wc.event_context)
-        ):
-            send_chatbot_trial_ended_email(account, event_context=wc.event_context)
+        maybe_send_chatbot_trial_ended_email(
+            wc, subscription, account, had_chatbot_access=had_chatbot_access
+        )
 
 
 @webhooks.handler("customer.subscription.updated")
@@ -833,6 +857,8 @@ def subscribe(event: Event, **kwargs):
 def unsubscribe(event: Event, **kwargs):
     """Revoke entitlements for a deleted Stripe subscription.
 
+    Also sends the chatbot trial-ended email if the subscription was still in trial.
+
     Args:
         event: The `customer.subscription.deleted` Stripe webhook event.
         **kwargs: Unused; accepted for compatibility with the djstripe
@@ -849,7 +875,11 @@ def unsubscribe(event: Event, **kwargs):
         subscription.save()
 
     account = get_account_for_stripe_customer(event)
+    had_chatbot_access = bool(account and account.has_chatbot_access)
     apply_inactive_subscription_entitlements(wc, subscription, account)
+    maybe_send_chatbot_trial_ended_email(
+        wc, subscription, account, had_chatbot_access=had_chatbot_access
+    )
 
 
 @webhooks.handler("customer.subscription.paused")

--- a/backend/apps/account_payment/webhooks.py
+++ b/backend/apps/account_payment/webhooks.py
@@ -545,7 +545,9 @@ def send_chatbot_trial_ended_email(account: Account, event_context: str = None) 
         msg.send()
         logger.info(f"{ctx}E-mail de fim de trial do chatbot enviado para {account.email}")
     except Exception as e:
-        logger.error(f"{ctx}Erro ao enviar e-mail de fim de trial do chatbot para {account.email}: {e}")
+        logger.error(
+            f"{ctx}Erro ao enviar e-mail de fim de trial do chatbot para {account.email}: {e}"
+        )
 
 
 def apply_active_subscription_entitlements(

--- a/backend/apps/user_notifications/templates/notification/update_table_notification.html
+++ b/backend/apps/user_notifications/templates/notification/update_table_notification.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html lang="pt-BR">
 
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
 </head>
 
 <body style="
@@ -11,28 +14,29 @@
   margin: 0 auto;
   width: 100%;
   max-width: 650px;
-  font-family: 'Lato',sans-serif;
+  font-family: 'Roboto', Arial, sans-serif;
   padding: 0 28px;
   box-sizing: content-box;
 ">
 
-  <a href="https://basedosdados.org" target="_blank" style="display: flex; width: 100%; margin: 20px 0;">
-    <img alt="logo" style="width: 75px; margin: 0 auto;" src="https://imgur.com/xoiXjjm.png">
+  <a href="https://basedosdados.org" target="_blank" style="display: block; width: 100%; margin: 20px 0; text-align: center;">
+    <img alt="logo" style="width: 100px; height: auto; display: inline-block; border: 0;" src="https://basedosdados.org/img/logo.png">
   </a>
 
-  <h1 style="width: 100%; padding-top: 32px; margin: 0 0 16px; border-top: 1px solid #DEDFE0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 700; line-height: 24px;">Olá,</h1>
+  <h1 style="width: 100%; padding-top: 32px; margin: 0 0 16px; border-top: 1px solid #DEDFE0; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 18px; font-style: normal; font-weight: 500; line-height: 28px;">Olá,</h1>
 
   <div style="display: block; width: 100%; margin: 16px 0;">
-    <p style="width: 100%; margin: 0; color: #252A32; font-family: Arial; font-size: 14px; font-style: normal; font-weight: 400; line-height: 22px;">Você pode conferir a atualização diretamente na plataforma das seguintes tabelas:</p>
+    <p style="width: 100%; margin: 0; color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 16px; font-style: normal; font-weight: 400; line-height: 24px;">Você pode conferir a atualização diretamente na plataforma das seguintes tabelas:</p>
   </div>
-  <ul style="width: 100%; padding-left: 20px; margin-top: 16px; list-style: none;"></ul>
+  <ul style="width: 100%; padding-left: 0; margin-top: 16px; list-style: none;">
     {% for subscription in subscriptions %}
       <li style="margin-bottom: 10px; list-style: none;">
         <a
           href="https://{{ domain }}/dataset/{{ subscription.table.dataset.id }}?table={{ subscription.table.id }}"
           target="_blank"
           rel="noopener noreferrer"
-          style="color: #252A32; text-decoration: none; font-weight: 500;"
+          class="link_dataset_table"
+          style="color: #252A32; text-decoration: none; font-family: 'Roboto', Arial, sans-serif; font-size: 14px; font-weight: 500; line-height: 20px;"
         >
           Tabela:
           <span style="color: #2B8C4D;">
@@ -43,7 +47,8 @@
           href="https://{{ domain }}/dataset/{{ subscription.table.dataset.id }}"
           target="_blank"
           rel="noopener noreferrer"
-          style="color: #252A32; text-decoration: none; font-weight: 500;"
+          class="link_dataset_table"
+          style="color: #252A32; text-decoration: none; font-family: 'Roboto', Arial, sans-serif; font-size: 14px; font-weight: 500; line-height: 20px;"
         >
           Dataset:
           <span style="color: #2B8C4D;">
@@ -52,17 +57,17 @@
         </a>
       </li>
     {% empty %}
-      <li style="color: #252A32; list-style: none;">Não há atualizações para suas tabelas no momento.</li>
+      <li style="color: #252A32; font-family: 'Roboto', Arial, sans-serif; font-size: 14px; font-weight: 400; line-height: 20px; list-style: none;">Não há atualizações para suas tabelas no momento.</li>
     {% endfor %}
   </ul>
 
   <span style="display: block; width: 100%; margin: 32px 0; border-top: 1px solid #DEDFE0;"></span>
 
   <div style="display: block; width: 100%; margin: 0 auto;">
-    <p style="color: #6F6F6F; text-align: center; font-family: Arial; font-size: 13px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; margin: 0;">
+    <p style="color: #6F6F6F; text-align: center; font-family: 'Roboto', Arial, sans-serif; font-size: 14px; font-weight: 400; line-height: 20px; margin: 0;">
       Se não quiser mais receber estes avisos, você pode desativar as notificações diretamente nas páginas de tabelas ou entrar em contato pelo e-mail
     </p>
-    <p style="width: 100%; text-align: center; color: #6F6F6F; margin: 0; font-family: Arial; font-size: 13px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; margin: 0; text-decoration: none;">
+    <p style="width: 100%; text-align: center; color: #6F6F6F; margin: 0; font-family: 'Roboto', Arial, sans-serif; font-size: 14px; font-weight: 400; line-height: 20px; text-decoration: none;">
       contato@basedosdados.org
     </p>
   </div>
@@ -70,8 +75,8 @@
   <span style="display: block; width: 100%; margin: 32px 0; border-top: 1px solid #DEDFE0;"></span>
 
   <div style="display: block; width: 100%; margin: 0 auto;">
-    <p style="text-align: center; color: #A3A3A3; font-family: Arial; font-size: 12px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; margin: 0;">Esta mensagem foi enviada pela</p>
-    <p style="text-align: center; color: #A3A3A3; font-family: Arial; font-size: 12px; font-weight: 400; line-height: 18px; letter-spacing: 0.2px; text-decoration: none; margin: 0;">Base dos Dados</p>
+    <p style="text-align: center; color: #A3A3A3; font-family: 'Roboto', Arial, sans-serif; font-size: 12px; font-weight: 400; line-height: 18px; margin: 0;">Esta mensagem foi enviada pela</p>
+    <p style="text-align: center; color: #A3A3A3; font-family: 'Roboto', Arial, sans-serif; font-size: 12px; font-weight: 400; line-height: 18px; text-decoration: none; margin: 0;">Base dos Dados</p>
   </div>
 
   <style>
@@ -83,7 +88,11 @@
     }
 
     .link_dataset_table:hover {
-      color: #2B8C4D !important;
+      color: #22703E !important;
+    }
+
+    .link_dataset_table:hover span {
+      color: #22703E !important;
     }
   </style>
 </body>


### PR DESCRIPTION
[Issue](https://github.com/basedosdados/website/issues/1598) da feature

## Summary
Esta branch adiciona o e-mail de fim de trial do chatbot e padroniza o visual dos templates transacionais da BD.

### E-mail de fim de trial do chatbot

- Novo template end_trial_chatbot.html, enviado automaticamente via webhook do Stripe quando a assinatura do chatbot sai de trialing e o acesso é revogado.
- Envio best-effort: falha no e-mail não impede a revogação do entitlement.

### Atualização visual dos e-mails

- Templates de ativação de conta, criação BD Pro, reset de senha e notificação de atualização de tabela alinhados ao novo padrão (fonte Roboto, logo atualizado, botões verdes, tipografia e espaçamentos revisados).
Correção no cancelamento de assinatura

- StripeSubscriptionDeleteMutation passa a usar cancel_at_period_end=True via API do Stripe em vez do helper do djstripe, evitando cancelamento imediato durante o período de trial.
