### PR TITLE
fix(account): Google OAuth originating domain + remove legacy Career fields

### DIFF
--- a/backend/apps/account/admin.py
+++ b/backend/apps/account/admin.py
@@ -342,9 +342,7 @@ class RoleAdmin(admin.ModelAdmin):
 class CareerAdmin(admin.ModelAdmin):
     list_display = (
         "account",
-        "team_old",
         "team",
-        "role_old",
         "role",
         "level",
         "start_at",
@@ -352,9 +350,7 @@ class CareerAdmin(admin.ModelAdmin):
     )
     search_fields = (
         "account__email",
-        "team_old",
         "team__name",
-        "role_old",
         "role__name",
     )
     readonly_fields = ("created_at", "updated_at")

--- a/backend/apps/account/migrations/0029_remove_career_team_old_remove_career_role_old.py
+++ b/backend/apps/account/migrations/0029_remove_career_team_old_remove_career_role_old.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("account", "0028_alter_account_uuid"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="career",
+            name="team_old",
+        ),
+        migrations.RemoveField(
+            model_name="career",
+            name="role_old",
+        ),
+    ]

--- a/backend/apps/account/models.py
+++ b/backend/apps/account/models.py
@@ -495,11 +495,9 @@ class Role(BaseModel):
 class Career(BaseModel):
     id = models.UUIDField(primary_key=True, default=uuid4)
     account = models.ForeignKey(Account, on_delete=models.DO_NOTHING, related_name="careers")
-    team_old = models.CharField("Team (old)", max_length=40, blank=True)
     team = models.ForeignKey(
         Team, on_delete=models.DO_NOTHING, related_name="careers", null=True, blank=True
     )
-    role_old = models.CharField("Role (old)", max_length=40, blank=True)
     role = models.ForeignKey(
         Role, on_delete=models.DO_NOTHING, related_name="careers", null=True, blank=True
     )

--- a/backend/apps/account/views.py
+++ b/backend/apps/account/views.py
@@ -22,7 +22,19 @@ from loguru import logger
 
 from backend.apps.account.signals import send_activation_email
 from backend.apps.account.token import token_generator
-from backend.custom.environment import get_frontend_url
+from backend.custom.environment import get_allowed_frontend_origins, get_frontend_url
+
+
+def _safe_frontend_origin(candidate):
+    """Return `candidate` only if it is an allowed frontend origin, else None.
+
+    Guards the Google OAuth redirect against open-redirect abuse: the success
+    URL carries a JWT, so the target origin must be on the per-environment
+    allowlist before it is trusted.
+    """
+    if candidate and candidate in get_allowed_frontend_origins():
+        return candidate
+    return None
 
 
 class AccountActivateView(View):
@@ -157,6 +169,16 @@ class GoogleAuthView(View):
             state = secrets.token_urlsafe(32)
             request.session["oauth_state"] = state
 
+            # Remember which frontend domain the login started on, so the
+            # callback returns the user there (pt/en/es live on sibling
+            # domains). Validated against the allowlist; unknown values are
+            # dropped and the callback falls back to settings.FRONTEND_URL.
+            redirect_origin = _safe_frontend_origin(request.GET.get("redirect_origin"))
+            if redirect_origin:
+                request.session["frontend_origin"] = redirect_origin
+            else:
+                request.session.pop("frontend_origin", None)
+
             auth_url = (
                 "https://accounts.google.com/o/oauth2/v2/auth?"
                 f"client_id={settings.GOOGLE_OAUTH_CLIENT_ID}&"
@@ -202,27 +224,37 @@ class GoogleCallbackView(View):
             if "oauth_state" in request.session:
                 del request.session["oauth_state"]
 
+            # Return the user to the domain they logged in from (set in
+            # GoogleAuthView); fall back to the static frontend if absent or
+            # no longer allowlisted.
+            frontend_base = (
+                _safe_frontend_origin(request.session.pop("frontend_origin", None))
+                or settings.FRONTEND_URL
+            )
+
             token_data = self._exchange_code_for_token(auth_code)
             if not token_data:
                 logger.error("Falha ao trocar código por token")
-                error_url = f"{settings.FRONTEND_URL}/user/login?error=auth_failed"
+                error_url = f"{frontend_base}/user/login?error=auth_failed"
                 return HttpResponseRedirect(error_url)
 
             user_info = self._get_user_info(token_data["access_token"])
             if not user_info:
                 logger.error("Não foi possível obter informações do usuário")
-                error_url = f"{settings.FRONTEND_URL}/user/login?error=user_info_failed"
+                error_url = f"{frontend_base}/user/login?error=user_info_failed"
                 return HttpResponseRedirect(error_url)
 
             account = self._create_or_update_account(user_info, token_data.get("id_token"))
 
             if account:
                 jwt_token = get_token(account)
-                frontend_url = f"{settings.FRONTEND_URL}/user/login?login=success&token={jwt_token}&id={account.id}"  # noqa: E501
+                frontend_url = (
+                    f"{frontend_base}/user/login?login=success&token={jwt_token}&id={account.id}"  # noqa: E501
+                )
                 return HttpResponseRedirect(frontend_url)
             else:
                 logger.error("Erro ao criar/atualizar conta")
-                error_url = f"{settings.FRONTEND_URL}/user/login?error=account_creation_failed"
+                error_url = f"{frontend_base}/user/login?error=account_creation_failed"
                 return HttpResponseRedirect(error_url)
 
         except Exception as e:

--- a/backend/custom/environment.py
+++ b/backend/custom/environment.py
@@ -58,6 +58,31 @@ def get_frontend_url():
     return "localhost:3000"
 
 
+# The three sibling frontends, one locale per domain (see the website's
+# next-i18next.config.js): pt -> basedosdados.org, en -> data-basis.org,
+# es -> basedelosdatos.org.
+FRONTEND_DOMAINS = ("basedosdados.org", "data-basis.org", "basedelosdatos.org")
+
+
+def get_allowed_frontend_origins():
+    """Allowed post-login redirect origins (scheme + host), by environment.
+
+    Google OAuth must return the user to the same domain they started on. The
+    callback picks the redirect target from this allowlist using the
+    `redirect_origin` the login page sends; anything off the list falls back to
+    the single static FRONTEND_URL. The allowlist is what makes honoring an
+    arbitrary redirect origin safe (a JWT rides in the redirect URL, so an
+    unvalidated origin would be an open redirect that leaks tokens).
+    """
+    if is_prd():
+        return {f"https://{d}" for d in FRONTEND_DOMAINS}
+    if is_stg():
+        return {f"https://staging.{d}" for d in FRONTEND_DOMAINS}
+    if is_dev():
+        return {f"https://development.{d}" for d in FRONTEND_DOMAINS}
+    return {"http://localhost:3000"}
+
+
 def production_task(func):
     """Decorator that avoids function call if it isn't production"""
 


### PR DESCRIPTION
Subset of #1057, cut fresh from `main` as requested — **Google login fixes and the migration only.
No Stripe or pricing changes.**

### What's here
- **#1046** `fix(account)`: return Google OAuth to the originating frontend domain.
  Adds a per-environment allowlist of the three sibling frontends (pt → basedosdados.org,
  en → data-basis.org, es → basedelosdatos.org) and honours a `redirect_origin` sent by the login
  page. The allowlist is what makes this safe: a JWT rides in the redirect URL, so an unvalidated
  origin would be an open redirect that leaks tokens. **Backward compatible** — when
  `redirect_origin` is absent or not allowlisted, it falls back to `settings.FRONTEND_URL`, i.e.
  exactly today's behaviour.
- **#1048** `refactor(account)`: remove legacy `Career.team_old` / `role_old`, with migration
  `account/0029_remove_career_team_old_remove_career_role_old`.

### Deliberately excluded
`#1044` (expose Stripe price id) and `#1045` (card-country regional price at checkout) stay on
#1057. There is **zero file overlap** between the two groups — this branch touches no
`account_payment/` file — so the split is clean and the two can land independently.

### Review notes
- **The migration drops two columns.** Its dependency `0028_alter_account_uuid` is already on
  `main`, so the chain is intact. Verified that the website frontend references neither
  `team_old`/`role_old` nor `teamOld`/`roleOld`, so this is invisible to the frontend.
- Both commits cherry-picked onto `main` with no conflicts; original authorship preserved and
  `(cherry picked from …)` provenance recorded on each.
