### PR TITLE
fix(ci): run the test suite, and repair the tests it was hiding

### DIFF
--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -17,6 +17,25 @@ jobs:
   test:
     name: Test python
     runs-on: ubuntu-latest
+    services:
+      database:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DB_HOST: localhost
+      DB_PORT: '5432'
+      DB_NAME: postgres
+      DB_USER: postgres
+      DB_PASSWORD: postgres
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,14 +48,20 @@ jobs:
           architecture: x64
           python-version: '3.11'
       - name: Install requirements
-        run: poetry install --only=test
+        # `--only=test` installed pytest without Django, so pytest aborted with
+        # ModuleNotFoundError on every run. The suite imports Django and the
+        # project's own apps, so the main group is required too.
+        run: poetry install --only main,test
       - name: Test
+        # `shell: bash` sets pipefail, so a pytest failure is not swallowed by tee.
+        shell: bash
         run: |
           poetry run pytest \
             --junitxml=pytest.xml \
             --cov-report=term-missing:skip-covered \
             --cov=backend backend | tee pytest-coverage.txt
       - name: Report coverage
+        if: always()
         uses: MishaKav/pytest-coverage-comment@main
         with:
           hide-report: true

--- a/backend/apps/account/test_password.py
+++ b/backend/apps/account/test_password.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""Tests for Account password handling.
+
+Account.save() decides for itself whether self.password holds a plaintext value
+to hash or an already-encoded hash to leave alone. Getting that wrong either
+stores a password in the clear or double-hashes it and locks the user out, and
+neither failure is visible from the outside.
+"""
+
+import pytest
+from django.contrib.auth.hashers import check_password as django_check_password
+from django.contrib.auth.hashers import make_password
+
+from backend.apps.account.models import Account, is_valid_encoded_password, split_password
+
+
+def make_account(**overrides):
+    fields = {
+        "username": "john.doe",
+        "email": "john.doe@email.com",
+        "first_name": "John",
+        "last_name": "Doe",
+    }
+    fields.update(overrides)
+    return Account(**fields)
+
+
+@pytest.mark.django_db
+def test_create_user_hashes_the_password():
+    account = Account.objects.create_user(
+        email="john.doe@email.com",
+        password="12345678",
+        username="john.doe",
+        first_name="John",
+        last_name="Doe",
+    )
+    assert account.password != "12345678"
+    assert account.check_password("12345678")
+
+
+@pytest.mark.django_db
+def test_plaintext_password_is_hashed_on_save():
+    """Assigning a raw password directly must not store it verbatim."""
+    account = make_account(password="12345678")
+    account.save()
+    account.refresh_from_db()
+    assert account.password != "12345678"
+    assert account.check_password("12345678")
+
+
+@pytest.mark.django_db
+def test_encoded_password_survives_save_unchanged():
+    """An already-hashed value must not be hashed a second time."""
+    encoded = make_password("12345678")
+    account = make_account(password=encoded)
+    account.save()
+    account.refresh_from_db()
+    assert account.password == encoded
+    assert account.check_password("12345678")
+
+
+@pytest.mark.django_db
+def test_resaving_does_not_invalidate_the_password():
+    account = Account.objects.create_user(
+        email="john.doe@email.com",
+        password="12345678",
+        username="john.doe",
+        first_name="John",
+        last_name="Doe",
+    )
+    account.first_name = "Johnny"
+    account.save()
+    account.refresh_from_db()
+    assert account.check_password("12345678")
+
+
+@pytest.mark.django_db
+def test_set_password_then_save_is_applied_once():
+    account = make_account(password="old-password")
+    account.save()
+    account.set_password("new-password")
+    account.save()
+    account.refresh_from_db()
+    assert account.check_password("new-password")
+    assert not account.check_password("old-password")
+
+
+@pytest.mark.django_db
+def test_new_accounts_are_inactive():
+    account = make_account(password="12345678")
+    account.save()
+    assert account.is_active is False
+
+
+@pytest.mark.django_db
+def test_create_user_rejects_a_missing_email():
+    with pytest.raises(ValueError):
+        Account.objects.create_user(email="", password="x", username="john.doe")
+
+
+@pytest.mark.django_db
+def test_create_user_rejects_a_missing_username():
+    with pytest.raises(ValueError):
+        Account.objects.create_user(email="john.doe@email.com", password="x")
+
+
+@pytest.mark.django_db
+def test_deleted_accounts_leave_the_default_queryset():
+    account = Account.objects.create_user(
+        email="john.doe@email.com",
+        password="12345678",
+        username="john.doe",
+        first_name="John",
+        last_name="Doe",
+    )
+    account.delete()
+    assert not Account.objects.filter(pk=account.pk).exists()
+    assert account.deleted_at is not None
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "first_name,last_name,expected",
+    [
+        ("John", "Doe", "John Doe"),
+        ("John", "", "John"),
+        ("", "Doe", "john.doe"),
+        ("", "", "john.doe"),
+    ],
+)
+def test_get_full_name(first_name, last_name, expected):
+    account = Account(username="john.doe", first_name=first_name, last_name=last_name)
+    assert account.get_full_name() == expected
+
+
+def test_split_password_returns_four_parts():
+    algorithm, iterations, salt, hashed = split_password(make_password("12345678"))
+    assert algorithm.startswith("pbkdf2")
+    assert iterations.isdigit()
+    assert salt and hashed
+
+
+def test_is_valid_encoded_password_accepts_a_django_hash():
+    assert is_valid_encoded_password(make_password("12345678")) is True
+
+
+@pytest.mark.parametrize("value", ["12345678", "", "not$a$hash", "md5$salt$hash"])
+def test_is_valid_encoded_password_rejects_non_hashes(value):
+    assert is_valid_encoded_password(value) is False
+
+
+def test_django_and_model_hashers_agree():
+    encoded = make_password("12345678")
+    assert django_check_password("12345678", encoded)
+    assert Account(password=encoded).check_password("12345678")

--- a/backend/apps/account/test_subscription.py
+++ b/backend/apps/account/test_subscription.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+"""Tests for the subscription properties on Account and Subscription.
+
+These decide what a paying user can reach: pro_subscription_status is read by the
+frontend and by CustomVerify to gate BD Pro features, and owner/member precedence
+determines whose plan applies when a user is both. The Stripe side is stubbed —
+the branch logic here is what breaks, not dj-stripe.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import PropertyMock, patch
+
+import pytest
+
+from backend.apps.account.models import Account, Subscription
+
+
+def stripe_sub(code="bd_pro", *, slots="5", status="active"):
+    """A stand-in for an internal Subscription with a Stripe plan behind it."""
+    return SimpleNamespace(
+        stripe_subscription=code,
+        stripe_subscription_slots=slots,
+        stripe_subscription_status=status,
+        is_pro="bd_pro" in code,
+    )
+
+
+def as_owner(sub):
+    return patch.object(Account, "pro_owner_subscription", PropertyMock(return_value=sub))
+
+
+def as_member(sub):
+    return patch.object(Account, "pro_member_subscription", PropertyMock(return_value=sub))
+
+
+@pytest.fixture(name="account")
+def fixture_account():
+    return Account.objects.create_user(
+        email="john.doe@email.com",
+        password="12345678",
+        username="john.doe",
+        first_name="John",
+        last_name="Doe",
+    )
+
+
+@pytest.fixture(name="member")
+def fixture_member():
+    return Account.objects.create_user(
+        email="jane.roe@email.com",
+        password="12345678",
+        username="jane.roe",
+        first_name="Jane",
+        last_name="Roe",
+    )
+
+
+# ---------------------------------------------------------------------------
+# No subscription
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_an_account_without_a_subscription_reports_nothing(account):
+    assert account.pro_owner_subscription is None
+    assert account.pro_member_subscription is None
+    assert account.pro_subscription is None
+    assert account.pro_subscription_role is None
+    assert account.pro_subscription_slots is None
+    assert account.pro_subscription_status is None
+    assert account.is_subscriber is False
+
+
+# ---------------------------------------------------------------------------
+# Owner and member
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_an_owner_reports_their_own_plan(account):
+    with as_owner(stripe_sub("bd_pro", slots="5")), as_member(None):
+        assert account.pro_subscription == "bd_pro"
+        assert account.pro_subscription_role == "owner"
+        assert account.pro_subscription_slots == "5"
+        assert account.is_subscriber is True
+
+
+@pytest.mark.django_db
+def test_a_member_reports_the_plan_they_belong_to(account):
+    with as_owner(None), as_member(stripe_sub("bd_pro_empresas", slots="20")):
+        assert account.pro_subscription == "bd_pro_empresas"
+        assert account.pro_subscription_role == "member"
+        assert account.pro_subscription_slots == "20"
+        assert account.is_subscriber is True
+
+
+@pytest.mark.django_db
+def test_being_an_owner_takes_precedence_over_being_a_member(account):
+    """Someone who owns one plan and belongs to another reports the one they own."""
+    with (
+        as_owner(stripe_sub("bd_pro", slots="5")),
+        as_member(stripe_sub("bd_pro_empresas", slots="20")),
+    ):
+        assert account.pro_subscription == "bd_pro"
+        assert account.pro_subscription_role == "owner"
+        assert account.pro_subscription_slots == "5"
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_a_trial_reads_as_active(account):
+    """The frontend gates on "active"; a trialing customer has paid-tier access."""
+    with as_owner(stripe_sub(status="trialing")), as_member(None):
+        assert account.pro_subscription_status == "active"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("status", ["active", "past_due", "canceled", "unpaid", "paused"])
+def test_every_other_status_passes_through(account, status):
+    with as_owner(stripe_sub(status=status)), as_member(None):
+        assert account.pro_subscription_status == status
+
+
+@pytest.mark.django_db
+def test_a_members_trial_is_converted_too(account):
+    with as_owner(None), as_member(stripe_sub(status="trialing")):
+        assert account.pro_subscription_status == "active"
+
+
+# ---------------------------------------------------------------------------
+# Which internal subscriptions count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_an_inactive_internal_subscription_is_not_a_pro_subscription(account):
+    Subscription.objects.create(admin=account, is_active=False)
+    assert account.pro_owner_subscription is None
+
+
+@pytest.mark.django_db
+def test_a_subscription_without_a_stripe_plan_is_not_pro(account):
+    """is_pro reads the Stripe product metadata, so a detached row cannot qualify."""
+    Subscription.objects.create(admin=account, is_active=True)
+    with pytest.raises(AttributeError):
+        _ = account.pro_owner_subscription
+
+
+# ---------------------------------------------------------------------------
+# Subscription membership
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_the_admin_is_listed_first_and_labelled(account):
+    subscription = Subscription.objects.create(admin=account, is_active=True)
+    assert subscription.subscribers_info == [{"email": "john.doe@email.com", "role": "admin"}]
+
+
+@pytest.mark.django_db
+def test_members_are_listed_after_the_admin(account, member):
+    subscription = Subscription.objects.create(admin=account, is_active=True)
+    subscription.subscribers.add(member)
+    assert subscription.subscribers_info == [
+        {"email": "john.doe@email.com", "role": "admin"},
+        {"email": "jane.roe@email.com", "role": "subscriber"},
+    ]
+
+
+@pytest.mark.django_db
+def test_the_admin_email_falls_back_to_a_placeholder(account):
+    subscription = Subscription.objects.create(admin=account, is_active=True)
+    assert subscription.admin_email == "john.doe@email.com"
+    account.email = ""
+    assert subscription.admin_email == "test@stripe.com"
+
+
+@pytest.mark.django_db
+def test_stripe_derived_dates_are_none_without_a_stripe_subscription(account):
+    subscription = Subscription.objects.create(admin=account, is_active=True)
+    assert subscription.canceled_at is None
+    assert subscription.plan_interval is None
+    assert subscription.next_billing_cycle is None
+
+
+# ---------------------------------------------------------------------------
+# Staff
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_is_staff_tracks_is_admin(account):
+    assert account.is_staff is False
+    account.is_admin = True
+    assert account.is_staff is True
+
+
+@pytest.mark.django_db
+def test_the_customer_is_the_first_linked_stripe_customer(account):
+    assert account.customer is None

--- a/backend/apps/account/test_views.py
+++ b/backend/apps/account/test_views.py
@@ -1,0 +1,399 @@
+# -*- coding: utf-8 -*-
+"""Tests for the account HTTP views.
+
+These are the account activation, password reset and Google OAuth endpoints.
+Two things here are security boundaries rather than ordinary behaviour: the
+OAuth `state` check that stops CSRF, and _safe_frontend_origin, which keeps the
+post-login redirect on an allowlist because that redirect carries a JWT in its
+query string. Both are asserted explicitly below.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core import mail
+from django.test.client import Client
+from django.urls import reverse
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+
+from backend.apps.account.models import Account
+from backend.apps.account.token import token_generator
+from backend.apps.account.views import GoogleCallbackView, _safe_frontend_origin
+
+
+@pytest.fixture(name="account")
+def fixture_account():
+    return Account.objects.create_user(
+        email="john.doe@email.com",
+        password="12345678",
+        username="john.doe",
+        first_name="John",
+        last_name="Doe",
+    )
+
+
+def uid_of(account):
+    return urlsafe_base64_encode(force_bytes(account.pk))
+
+
+# ---------------------------------------------------------------------------
+# Account activation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_activation_email_is_sent_for_a_known_uid(client: Client, account):
+    response = client.post(reverse("activate", args=[uid_of(account)]))
+    assert response.status_code == 200
+    assert response.json() == {}
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].to == ["john.doe@email.com"]
+    assert mail.outbox[0].subject == "Bem Vindo à Base dos Dados!"
+
+
+@pytest.mark.django_db
+def test_activation_rejects_a_malformed_uid(client: Client):
+    response = client.post(reverse("activate", args=["not-a-uid"]))
+    assert response.status_code == 422
+    assert mail.outbox == []
+
+
+@pytest.mark.django_db
+def test_activation_rejects_an_unknown_account(client: Client):
+    unknown = urlsafe_base64_encode(force_bytes("00000000-0000-0000-0000-000000000000"))
+    response = client.post(reverse("activate", args=[unknown]))
+    assert response.status_code == 422
+
+
+@pytest.mark.django_db
+def test_a_valid_token_activates_the_account(client: Client, account):
+    assert account.is_active is False
+    url = reverse("activate", args=[uid_of(account), token_generator.make_token(account)])
+    response = client.post(url)
+    assert response.status_code == 200
+    account.refresh_from_db()
+    assert account.is_active is True
+
+
+@pytest.mark.django_db
+def test_an_invalid_token_does_not_activate_the_account(client: Client, account):
+    url = reverse("activate", args=[uid_of(account), "wrong-token"])
+    response = client.post(url)
+    assert response.status_code == 422
+    account.refresh_from_db()
+    assert account.is_active is False
+
+
+# ---------------------------------------------------------------------------
+# Password reset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_password_reset_emails_a_known_account(client: Client, account):
+    response = client.post(reverse("password_reset", args=[uid_of(account)]))
+    assert response.status_code == 200
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].subject == "Base dos Dados: Redefinição de Senha"
+    assert mail.outbox[0].to == ["john.doe@email.com"]
+
+
+@pytest.mark.django_db
+def test_password_reset_rejects_an_unknown_uid(client: Client):
+    response = client.post(reverse("password_reset", args=["not-a-uid"]))
+    assert response.status_code == 422
+    assert mail.outbox == []
+
+
+@pytest.mark.django_db
+def test_a_valid_token_changes_the_password(client: Client, account):
+    url = reverse(
+        "password_reset_confirm", args=[uid_of(account), token_generator.make_token(account)]
+    )
+    response = client.post(url, data={"password": "new-password"}, content_type="application/json")
+    assert response.status_code == 200
+    account.refresh_from_db()
+    assert account.check_password("new-password")
+    assert not account.check_password("12345678")
+
+
+@pytest.mark.django_db
+def test_an_invalid_token_leaves_the_password_alone(client: Client, account):
+    url = reverse("password_reset_confirm", args=[uid_of(account), "wrong-token"])
+    response = client.post(url, data={"password": "new-password"}, content_type="application/json")
+    assert response.status_code == 422
+    account.refresh_from_db()
+    assert account.check_password("12345678")
+
+
+@pytest.mark.django_db
+def test_a_token_does_not_work_twice(client: Client, account):
+    """Changing the password invalidates the token that authorised the change."""
+    token = token_generator.make_token(account)
+    url = reverse("password_reset_confirm", args=[uid_of(account), token])
+    assert (
+        client.post(
+            url, data={"password": "first-password"}, content_type="application/json"
+        ).status_code
+        == 200
+    )
+    assert (
+        client.post(
+            url, data={"password": "second-password"}, content_type="application/json"
+        ).status_code
+        == 422
+    )
+    account.refresh_from_db()
+    assert account.check_password("first-password")
+
+
+# ---------------------------------------------------------------------------
+# The redirect allowlist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_safe_frontend_origin_accepts_an_allowlisted_origin():
+    """Outside a remote environment the allowlist is the local frontend."""
+    assert _safe_frontend_origin("http://localhost:3000") == "http://localhost:3000"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "https://evil.example.com",
+        "http://localhost:3000.evil.com",
+        "https://basedosdados.org",  # a production origin, not allowed locally
+        "",
+        None,
+    ],
+)
+def test_safe_frontend_origin_rejects_everything_else(candidate):
+    assert _safe_frontend_origin(candidate) is None
+
+
+# ---------------------------------------------------------------------------
+# Google OAuth: starting the flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_google_login_redirects_to_google_and_stores_state(client: Client):
+    response = client.get(reverse("google_auth"))
+    assert response.status_code == 302
+    assert response.url.startswith("https://accounts.google.com/o/oauth2/v2/auth?")
+    state = client.session["oauth_state"]
+    assert state and f"state={state}" in response.url
+
+
+@pytest.mark.django_db
+def test_google_login_remembers_an_allowlisted_origin(client: Client):
+    client.get(reverse("google_auth"), {"redirect_origin": "http://localhost:3000"})
+    assert client.session["frontend_origin"] == "http://localhost:3000"
+
+
+@pytest.mark.django_db
+def test_google_login_discards_an_unlisted_origin(client: Client):
+    client.get(reverse("google_auth"), {"redirect_origin": "https://evil.example.com"})
+    assert "frontend_origin" not in client.session
+
+
+# ---------------------------------------------------------------------------
+# Google OAuth: the callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_callback_reports_an_error_from_google(client: Client):
+    response = client.get(reverse("google_callback"), {"error": "access_denied"})
+    assert response.status_code == 400
+    assert "access_denied" in response.json()["error"]
+
+
+@pytest.mark.django_db
+def test_callback_requires_an_authorization_code(client: Client):
+    response = client.get(reverse("google_callback"), {"state": "whatever"})
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_callback_rejects_a_mismatched_state(client: Client):
+    """The state check is what stops a cross-site request forging a login."""
+    client.get(reverse("google_auth"))
+    response = client.get(reverse("google_callback"), {"code": "abc", "state": "attacker"})
+    assert response.status_code == 400
+    assert response.json()["error"] == "Estado inválido"
+
+
+@pytest.mark.django_db
+def test_callback_rejects_a_missing_state(client: Client):
+    client.get(reverse("google_auth"))
+    response = client.get(reverse("google_callback"), {"code": "abc"})
+    assert response.status_code == 400
+
+
+def start_flow(client, **params):
+    """Run the login step so the session carries a valid state, and return it."""
+    client.get(reverse("google_auth"), params)
+    return client.session["oauth_state"]
+
+
+@pytest.mark.django_db
+@patch.object(GoogleCallbackView, "_get_user_info")
+@patch.object(GoogleCallbackView, "_exchange_code_for_token")
+def test_callback_creates_an_account_and_redirects_with_a_token(
+    exchange: MagicMock, user_info: MagicMock, client: Client
+):
+    exchange.return_value = {"access_token": "at", "id_token": "it"}
+    user_info.return_value = {"email": "jane@email.com", "id": "google-123", "name": "Jane Roe"}
+
+    state = start_flow(client)
+    response = client.get(reverse("google_callback"), {"code": "abc", "state": state})
+
+    assert response.status_code == 302
+    assert "login=success" in response.url
+    assert "token=" in response.url
+
+    account = Account.objects.get(email="jane@email.com")
+    assert account.is_active is True
+    assert account.google_sub == "google-123"
+    assert account.first_name == "Jane"
+    assert account.last_name == "Roe"
+
+
+@pytest.mark.django_db
+@patch.object(GoogleCallbackView, "_get_user_info")
+@patch.object(GoogleCallbackView, "_exchange_code_for_token")
+def test_callback_returns_to_the_origin_the_login_started_on(
+    exchange: MagicMock, user_info: MagicMock, client: Client
+):
+    exchange.return_value = {"access_token": "at"}
+    user_info.return_value = {"email": "jane@email.com", "id": "google-123", "name": "Jane"}
+
+    state = start_flow(client, redirect_origin="http://localhost:3000")
+    response = client.get(reverse("google_callback"), {"code": "abc", "state": state})
+    assert response.url.startswith("http://localhost:3000/user/login")
+
+
+@pytest.mark.django_db
+@patch.object(GoogleCallbackView, "_exchange_code_for_token", return_value=None)
+def test_callback_redirects_with_an_error_when_the_exchange_fails(
+    exchange: MagicMock, client: Client
+):
+    state = start_flow(client)
+    response = client.get(reverse("google_callback"), {"code": "abc", "state": state})
+    assert response.status_code == 302
+    assert "error=auth_failed" in response.url
+
+
+@pytest.mark.django_db
+@patch.object(GoogleCallbackView, "_get_user_info", return_value=None)
+@patch.object(GoogleCallbackView, "_exchange_code_for_token")
+def test_callback_redirects_with_an_error_when_user_info_fails(
+    exchange: MagicMock, user_info: MagicMock, client: Client
+):
+    exchange.return_value = {"access_token": "at"}
+    state = start_flow(client)
+    response = client.get(reverse("google_callback"), {"code": "abc", "state": state})
+    assert "error=user_info_failed" in response.url
+
+
+@pytest.mark.django_db
+@patch.object(GoogleCallbackView, "_get_user_info")
+@patch.object(GoogleCallbackView, "_exchange_code_for_token")
+def test_callback_redirects_with_an_error_when_the_account_cannot_be_built(
+    exchange: MagicMock, user_info: MagicMock, client: Client
+):
+    exchange.return_value = {"access_token": "at"}
+    user_info.return_value = {"name": "No Email"}  # missing email and id
+    state = start_flow(client)
+    response = client.get(reverse("google_callback"), {"code": "abc", "state": state})
+    assert "error=account_creation_failed" in response.url
+
+
+# ---------------------------------------------------------------------------
+# Account creation from Google profile data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_google_account_creation_derives_a_username_from_the_email():
+    account = GoogleCallbackView()._create_or_update_account(
+        {"email": "jane.roe@email.com", "id": "google-123", "name": "Jane Roe"}
+    )
+    assert account.username == "jane.roe"
+
+
+@pytest.mark.django_db
+def test_google_account_creation_disambiguates_a_taken_username(account):
+    """account already holds the username "john.doe"."""
+    created = GoogleCallbackView()._create_or_update_account(
+        {"email": "john.doe@other.com", "id": "google-456", "name": "John Doe"}
+    )
+    assert created.username == "john.doe1"
+
+
+@pytest.mark.django_db
+def test_google_login_links_and_activates_an_existing_account(account):
+    assert account.is_active is False
+    linked = GoogleCallbackView()._create_or_update_account(
+        {"email": "john.doe@email.com", "id": "google-789", "name": "John Doe"}
+    )
+    assert linked.pk == account.pk
+    assert linked.google_sub == "google-789"
+    account.refresh_from_db()
+    assert account.is_active is True
+
+
+@pytest.mark.django_db
+def test_a_single_word_name_leaves_the_last_name_empty():
+    account = GoogleCallbackView()._create_or_update_account(
+        {"email": "cher@email.com", "id": "google-1", "name": "Cher"}
+    )
+    assert account.first_name == "Cher"
+    assert account.last_name == ""
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_info",
+    [
+        {"id": "google-1", "name": "No Email"},
+        {"email": "no.sub@email.com", "name": "No Sub"},
+        {},
+    ],
+)
+def test_google_account_creation_requires_an_email_and_a_google_id(user_info):
+    assert GoogleCallbackView()._create_or_update_account(user_info) is None
+
+
+@pytest.mark.django_db
+def test_token_exchange_returns_none_on_a_request_error():
+    with patch("backend.apps.account.views.requests.post") as post:
+        post.side_effect = __import__("requests").RequestException("boom")
+        assert GoogleCallbackView()._exchange_code_for_token("abc") is None
+
+
+@pytest.mark.django_db
+def test_user_info_returns_none_on_a_request_error():
+    with patch("backend.apps.account.views.requests.get") as get:
+        get.side_effect = __import__("requests").RequestException("boom")
+        assert GoogleCallbackView()._get_user_info("at") is None
+
+
+@pytest.mark.django_db
+def test_token_exchange_returns_the_payload():
+    with patch("backend.apps.account.views.requests.post") as post:
+        post.return_value.json.return_value = {"access_token": "at"}
+        post.return_value.raise_for_status.return_value = None
+        assert GoogleCallbackView()._exchange_code_for_token("abc") == {"access_token": "at"}
+
+
+@pytest.mark.django_db
+def test_user_info_returns_the_payload():
+    with patch("backend.apps.account.views.requests.get") as get:
+        get.return_value.json.return_value = {"email": "jane@email.com"}
+        get.return_value.raise_for_status.return_value = None
+        assert GoogleCallbackView()._get_user_info("at") == {"email": "jane@email.com"}

--- a/backend/apps/account/tests.py
+++ b/backend/apps/account/tests.py
@@ -20,8 +20,9 @@ def test_account_create():
 
 
 @pytest.mark.django_db
+@patch("backend.apps.account.signals.is_prd", return_value=True)
 @patch("backend.apps.account.signals.EmailMultiAlternatives")
-def test_activate_account_signal(mock: MagicMock):
+def test_activate_account_signal(mock: MagicMock, _is_prd: MagicMock):
     Account.objects.create(
         username="john.doe",
         email="john.doe@email.com",
@@ -32,8 +33,9 @@ def test_activate_account_signal(mock: MagicMock):
 
 
 @pytest.mark.django_db
+@patch("backend.apps.account.signals.is_prd", return_value=True)
 @patch("backend.apps.account.signals.render_to_string")
-def test_activate_account_confirmation(mock: MagicMock, client: Client):
+def test_activate_account_confirmation(mock: MagicMock, _is_prd: MagicMock, client: Client):
     account = Account.objects.create(
         username="john.doe",
         email="john.doe@email.com",
@@ -70,9 +72,12 @@ def test_password_reset_request(mock: MagicMock, client: Client):
 
 
 @pytest.mark.django_db
+@patch("backend.apps.account.signals.is_prd", return_value=True)
 @patch("backend.apps.account.views.render_to_string")
 @patch("backend.apps.account.signals.render_to_string")
-def test_password_reset_confirmation(mock_signal: MagicMock, mock_view: MagicMock, client: Client):
+def test_password_reset_confirmation(
+    mock_signal: MagicMock, mock_view: MagicMock, _is_prd: MagicMock, client: Client
+):
     # Create account
     account = Account.objects.create(
         username="john.doe",

--- a/backend/apps/account_auth/models.py
+++ b/backend/apps/account_auth/models.py
@@ -32,9 +32,9 @@ class Token(models.Model):
     def generate_token(self):
         return str(uuid4())
 
-    def save(self):
+    def save(self, *args, **kwargs):
         self.token = self.generate_token()
-        super().save()
+        super().save(*args, **kwargs)
 
 
 class Access(models.Model):

--- a/backend/apps/account_auth/tests.py
+++ b/backend/apps/account_auth/tests.py
@@ -1,3 +1,333 @@
 # -*- coding: utf-8 -*-
+"""Tests for the account_auth gateway.
 
-# Create your tests here.
+`/auth/` is an authorization endpoint: a reverse proxy calls it to decide whether
+a request may reach a protected domain, so a 200 returned by mistake is an
+authorization bypass. authorize() is the function that decides, and it has six
+separate ways to say no. Each is covered here.
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.test.client import Client
+from django.utils import timezone
+
+from backend.apps.account.models import Account
+from backend.apps.account_auth.models import Access, Domain, Token
+from backend.apps.account_auth.views import get_redirect_uri, store_access
+
+PROTECTED = "https://protected.basedosdados.org/dashboard"
+
+
+@pytest.fixture(name="domain")
+def fixture_domain():
+    return Domain.objects.create(name="protected.basedosdados.org")
+
+
+@pytest.fixture(name="user")
+def fixture_user():
+    account = Account.objects.create_user(
+        email="john.doe@email.com",
+        password="12345678",
+        username="john.doe",
+        first_name="John",
+        last_name="Doe",
+    )
+    account.is_active = True
+    account.save()
+    return account
+
+
+@pytest.fixture(name="token")
+def fixture_token(user, domain):
+    return Token.objects.create(user=user, domain=domain)
+
+
+def auth(client, *, token=None, url=PROTECTED):
+    headers = {"HTTP_X_ORIGINAL_URL": url} if url else {}
+    if token:
+        headers["HTTP_AUTHORIZATION"] = f"Bearer {token}"
+    return client.get("/auth/", **headers)
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_no_redirect_uri_is_refused(client: Client):
+    assert auth(client, url=None).status_code == 401
+
+
+@pytest.mark.django_db
+def test_an_unregistered_domain_is_refused(client: Client, token):
+    response = auth(client, token=token.token, url="https://not-registered.example.com/x")
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_a_missing_authorization_header_is_refused(client: Client, domain):
+    assert auth(client).status_code == 401
+
+
+@pytest.mark.django_db
+def test_a_malformed_authorization_header_is_refused(client: Client, domain):
+    response = client.get("/auth/", HTTP_X_ORIGINAL_URL=PROTECTED, HTTP_AUTHORIZATION="Bearer")
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_an_unknown_token_is_refused(client: Client, domain):
+    assert auth(client, token="not-a-real-token").status_code == 401
+
+
+@pytest.mark.django_db
+def test_a_token_for_another_domain_is_refused(client: Client, user, domain):
+    other = Domain.objects.create(name="other.basedosdados.org")
+    other_token = Token.objects.create(user=user, domain=other)
+    assert auth(client, token=other_token.token).status_code == 401
+
+
+@pytest.mark.django_db
+def test_an_inactive_token_is_refused(client: Client, token):
+    token.is_active = False
+    Token.objects.filter(pk=token.pk).update(is_active=False)
+    assert auth(client, token=token.token).status_code == 401
+
+
+@pytest.mark.django_db
+def test_an_expired_token_is_refused(client: Client, token):
+    Token.objects.filter(pk=token.pk).update(expiry_date=timezone.now() - timedelta(days=1))
+    assert auth(client, token=token.token).status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Grants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_a_valid_token_is_accepted(client: Client, token):
+    assert auth(client, token=token.token).status_code == 200
+
+
+@pytest.mark.django_db
+def test_a_token_with_a_future_expiry_is_accepted(client: Client, token):
+    Token.objects.filter(pk=token.pk).update(expiry_date=timezone.now() + timedelta(days=1))
+    assert auth(client, token=token.token).status_code == 200
+
+
+@pytest.mark.django_db
+def test_a_token_with_no_expiry_never_expires(client: Client, token):
+    assert token.expiry_date is None
+    assert auth(client, token=token.token).status_code == 200
+
+
+@pytest.mark.django_db
+def test_a_logged_in_staff_user_is_accepted_without_a_token(client: Client, user, domain):
+    user.is_admin = True
+    user.save()
+    client.force_login(user)
+    assert auth(client).status_code == 200
+
+
+@pytest.mark.django_db
+def test_a_logged_in_user_with_a_matching_token_is_accepted(client: Client, user, token):
+    client.force_login(user)
+    assert auth(client).status_code == 200
+
+
+@pytest.mark.django_db
+def test_a_logged_in_user_without_a_token_for_the_domain_is_refused(client: Client, user, domain):
+    client.force_login(user)
+    assert auth(client).status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Failed attempts are recorded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_a_refusal_is_recorded(client: Client, domain):
+    auth(client)
+    assert Access.objects.filter(success=False).count() == 1
+
+
+@pytest.mark.django_db
+def test_a_grant_is_not_recorded(client: Client, token):
+    auth(client, token=token.token)
+    assert Access.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_store_access_resolves_string_arguments(token, domain, user):
+    store_access(token=token.token, domain=domain.name, user=None, success=True)
+    access = Access.objects.get()
+    assert access.token == token
+    assert access.domain == domain
+    assert access.user == user  # inferred from the token
+
+
+@pytest.mark.django_db
+def test_store_access_tolerates_unknown_names():
+    store_access(token="nope", domain="nope", user=None, success=False)
+    access = Access.objects.get()
+    assert access.token is None
+    assert access.domain is None
+
+
+# ---------------------------------------------------------------------------
+# Redirect URI resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_the_original_url_header_wins(rf):
+    request = rf.get("/auth/", {"rd": "https://from-query.example.com"})
+    request.META["HTTP_X_ORIGINAL_URL"] = "https://from-header.example.com"
+    assert get_redirect_uri(request) == "https://from-header.example.com"
+
+
+@pytest.mark.django_db
+def test_the_rd_query_parameter_is_the_fallback(rf):
+    request = rf.get("/auth/", {"rd": "https://from-query.example.com"})
+    assert get_redirect_uri(request) == "https://from-query.example.com"
+
+
+@pytest.mark.django_db
+def test_the_default_is_returned_when_neither_is_present(rf):
+    assert get_redirect_uri(rf.get("/auth/"), default="fallback") == "fallback"
+    assert get_redirect_uri(rf.get("/auth/")) is None
+
+
+# ---------------------------------------------------------------------------
+# Sign in and sign out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_the_signin_page_renders(client: Client):
+    response = client.get("/auth/login/")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_signin_requires_a_captcha(client: Client):
+    response = client.post(
+        "/auth/login/", {"username": "john.doe@email.com", "password": "12345678"}
+    )
+    assert response.status_code == 401
+    assert b"Invalid captcha" in response.content
+
+
+@pytest.mark.django_db
+@patch("backend.apps.account_auth.views.validate_recaptcha_token", return_value=True)
+def test_signin_rejects_bad_credentials(captcha, client: Client, user):
+    response = client.post(
+        "/auth/login/",
+        {
+            "username": "john.doe@email.com",
+            "password": "wrong-password",
+            "g-recaptcha-response": "ok",
+        },
+    )
+    assert response.status_code == 401
+    assert b"Invalid username or password" in response.content
+
+
+@pytest.mark.django_db
+@patch("backend.apps.account_auth.views.validate_recaptcha_token", return_value=True)
+def test_signin_without_a_redirect_asks_for_one(captcha, client: Client, user):
+    response = client.post(
+        "/auth/login/",
+        {
+            "username": "john.doe@email.com",
+            "password": "12345678",
+            "g-recaptcha-response": "ok",
+        },
+    )
+    assert response.status_code == 422
+    assert b"Please specify a redirect URL" in response.content
+
+
+@pytest.mark.django_db
+@patch("backend.apps.account_auth.views.validate_recaptcha_token", return_value=True)
+def test_signin_redirects_on_success(captcha, client: Client, user, domain):
+    response = client.post(
+        f"/auth/login/?rd={PROTECTED}",
+        {
+            "username": "john.doe@email.com",
+            "password": "12345678",
+            "g-recaptcha-response": "ok",
+        },
+    )
+    assert response.status_code == 302
+    assert response.url == PROTECTED
+
+
+@pytest.mark.django_db
+def test_signout_redirects_to_login(client: Client, user):
+    client.force_login(user)
+    response = client.get("/auth/logout/")
+    assert response.status_code == 302
+    assert client.get("/auth/login/", follow=False).status_code == 200
+
+
+@pytest.mark.django_db
+def test_signout_is_safe_when_no_one_is_logged_in(client: Client):
+    assert client.get("/auth/logout/").status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_a_token_value_is_generated_on_save(user, domain):
+    token = Token.objects.create(user=user, domain=domain)
+    assert token.token
+    other = Token.objects.create(user=user, domain=domain)
+    assert token.token != other.token
+
+
+@pytest.mark.django_db
+def test_saving_an_existing_token_rotates_its_value(user, domain):
+    """Recorded, not endorsed: Token.save() regenerates unconditionally.
+
+    Any later save rotates the token, so editing a Token in the admin, for
+    instance to set an expiry date, silently invalidates the value the client
+    is already using. Guarding the assignment with `if not self.token` would
+    fix it, but that changes how an auth credential behaves and is left as a
+    decision for the team rather than folded into a testing change.
+    """
+    token = Token.objects.create(user=user, domain=domain)
+    original = token.token
+    token.expiry_date = timezone.now() + timedelta(days=30)
+    token.save()
+    assert token.token != original
+
+
+@pytest.mark.django_db
+def test_model_string_representations(token, domain, user):
+    assert str(domain) == "protected.basedosdados.org"
+    assert str(token).startswith("john.doe - protected.basedosdados.org - ")
+    access = Access.objects.create(token=token, domain=domain, user=user, success=True)
+    assert " - OK - " in str(access)
+    denied = Access.objects.create(success=False)
+    assert " - ERR - NO_DOMAIN - NO_TOKEN" in str(denied)
+
+
+@pytest.mark.django_db
+def test_recaptcha_validation_reads_the_google_response():
+    from backend.apps.account_auth.views import validate_recaptcha_token
+
+    with patch("backend.apps.account_auth.views.post") as post:
+        post.return_value.json.return_value = {"success": True}
+        assert validate_recaptcha_token("t") is True
+        post.return_value.json.return_value = {"success": False}
+        assert validate_recaptcha_token("t") is False

--- a/backend/apps/account_payment/test_trials.py
+++ b/backend/apps/account_payment/test_trials.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+"""Tests for trial eligibility and chatbot product detection.
+
+djstripe_subscription_is_chatbot decides which entitlement a Stripe webhook
+grants or revokes: chatbot access, or Google Group membership. It reads the
+product `code` metadata down two different paths (plan.product, or the first
+line item's price.product) and swallows every exception, so a wrong answer is
+silent — the customer simply doesn't get what they paid for.
+
+The Stripe objects are stubbed rather than built in the database: these
+functions only ever reach for `plan.product.metadata` or `items.first()`, and
+duck types make the shape being relied on explicit.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from backend.apps.account_payment import trials
+from backend.apps.account_payment.trials import (
+    IGNORED_SUBSCRIPTION_STATUSES,
+    account_eligible_for_bdpro_stripe_trial,
+    account_eligible_for_chatbot_stripe_trial,
+    account_has_prior_chatbot_subscription,
+    account_has_prior_non_chatbot_subscription,
+    djstripe_subscription_is_chatbot,
+)
+
+
+def product(code):
+    return SimpleNamespace(metadata={"code": code})
+
+
+def sub_with_plan(code):
+    """A subscription whose product is reachable via plan.product."""
+    return SimpleNamespace(plan=SimpleNamespace(product=product(code)))
+
+
+def sub_with_item(code):
+    """A subscription whose product is only reachable via its first line item."""
+    return SimpleNamespace(
+        plan=None,
+        items=SimpleNamespace(
+            first=lambda: SimpleNamespace(price=SimpleNamespace(product=product(code)))
+        ),
+    )
+
+
+class FakeQuerySet:
+    def __init__(self, items):
+        self._items = items
+
+    def iterator(self, chunk_size=None):
+        return iter(self._items)
+
+
+# ---------------------------------------------------------------------------
+# Product detection
+# ---------------------------------------------------------------------------
+
+
+def test_plan_product_marks_a_chatbot_subscription():
+    assert djstripe_subscription_is_chatbot(sub_with_plan("chatbot")) is True
+
+
+def test_plan_product_marks_a_non_chatbot_subscription():
+    assert djstripe_subscription_is_chatbot(sub_with_plan("bd_pro")) is False
+
+
+def test_the_line_item_price_is_the_fallback_path():
+    assert djstripe_subscription_is_chatbot(sub_with_item("chatbot")) is True
+    assert djstripe_subscription_is_chatbot(sub_with_item("bd_pro")) is False
+
+
+def test_the_match_is_exact_not_a_substring():
+    """ "chatbot_annual" is a different product and must not match."""
+    assert djstripe_subscription_is_chatbot(sub_with_plan("chatbot_annual")) is False
+    assert djstripe_subscription_is_chatbot(sub_with_plan("Chatbot")) is False
+
+
+def test_missing_metadata_is_not_a_chatbot():
+    assert djstripe_subscription_is_chatbot(sub_with_plan("")) is False
+    assert djstripe_subscription_is_chatbot(SimpleNamespace(plan=None, items=None)) is False
+
+
+def test_a_broken_subscription_object_is_not_a_chatbot():
+    """The helper swallows errors and answers False rather than raising."""
+
+    class Exploding:
+        @property
+        def plan(self):
+            raise RuntimeError("stripe is down")
+
+    assert djstripe_subscription_is_chatbot(Exploding()) is False
+
+
+def test_an_empty_item_list_is_not_a_chatbot():
+    sub = SimpleNamespace(plan=None, items=SimpleNamespace(first=lambda: None))
+    assert djstripe_subscription_is_chatbot(sub) is False
+
+
+# ---------------------------------------------------------------------------
+# Prior subscriptions and trial eligibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="account")
+def fixture_account(db):
+    from backend.apps.account.models import Account
+
+    return Account.objects.create_user(
+        email="john.doe@email.com",
+        password="12345678",
+        username="john.doe",
+        first_name="John",
+        last_name="Doe",
+    )
+
+
+def with_subscriptions(*subs):
+    return patch.object(trials, "account_djstripe_subscriptions", return_value=FakeQuerySet(subs))
+
+
+@pytest.mark.django_db
+def test_no_history_means_both_trials_are_available(account):
+    with with_subscriptions():
+        assert account_eligible_for_bdpro_stripe_trial(account) is True
+        assert account_eligible_for_chatbot_stripe_trial(account) is True
+
+
+@pytest.mark.django_db
+def test_a_prior_bdpro_subscription_burns_only_the_bdpro_trial(account):
+    with with_subscriptions(sub_with_plan("bd_pro")):
+        assert account_has_prior_non_chatbot_subscription(account) is True
+        assert account_has_prior_chatbot_subscription(account) is False
+        assert account_eligible_for_bdpro_stripe_trial(account) is False
+        assert account_eligible_for_chatbot_stripe_trial(account) is True
+
+
+@pytest.mark.django_db
+def test_a_prior_chatbot_subscription_burns_only_the_chatbot_trial(account):
+    with with_subscriptions(sub_with_plan("chatbot")):
+        assert account_has_prior_chatbot_subscription(account) is True
+        assert account_has_prior_non_chatbot_subscription(account) is False
+        assert account_eligible_for_chatbot_stripe_trial(account) is False
+        assert account_eligible_for_bdpro_stripe_trial(account) is True
+
+
+@pytest.mark.django_db
+def test_a_history_of_both_burns_both_trials(account):
+    with with_subscriptions(sub_with_plan("chatbot"), sub_with_plan("bd_pro")):
+        assert account_eligible_for_bdpro_stripe_trial(account) is False
+        assert account_eligible_for_chatbot_stripe_trial(account) is False
+
+
+def test_incomplete_subscriptions_are_ignored_when_looking_at_history():
+    """An abandoned checkout must not burn a trial."""
+    assert IGNORED_SUBSCRIPTION_STATUSES == frozenset({"incomplete", "incomplete_expired"})

--- a/backend/apps/account_payment/test_webhooks.py
+++ b/backend/apps/account_payment/test_webhooks.py
@@ -1,0 +1,253 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Stripe webhook helpers.
+
+These are the guards every subscription handler runs before it grants or revokes
+anything: the customer/email precondition, the account lookup, product
+resolution, and the admin protection in _set_account_chatbot_access. All of them
+fail quietly by design — they log and return None or False rather than raise —
+so without tests a regression looks exactly like a customer who never paid.
+
+Stripe events are stubbed. The helpers only touch `event.customer.email`,
+`event.type`, `event.id` and `event.data["object"]["id"]`, and a duck type makes
+that surface explicit.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from backend.apps.account.models import Account
+from backend.apps.account_payment.webhooks import (
+    WebhookContext,
+    _normalize_plus,
+    _set_account_chatbot_access,
+    get_account_for_stripe_customer,
+    get_product_slug,
+    get_subscription,
+    require_webhook_customer_context,
+    subscription_product_is_chatbot,
+)
+
+
+def fake_event(email="john.doe@email.com", *, object_id="sub_123", type="customer.updated"):
+    customer = SimpleNamespace(email=email) if email is not None else None
+    return SimpleNamespace(
+        customer=customer,
+        type=type,
+        id="evt_1",
+        data={"object": {"id": object_id}},
+    )
+
+
+def product(code):
+    return SimpleNamespace(metadata={"code": code})
+
+
+@pytest.fixture(name="account")
+def fixture_account():
+    return Account.objects.create_user(
+        email="john.doe@email.com",
+        password="12345678",
+        username="john.doe",
+        first_name="John",
+        last_name="Doe",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Email normalisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("user@example.com", "user@example.com"),
+        ("User@Example.com", "user@example.com"),
+        ("  user@example.com  ", "user@example.com"),
+        ("user+test@example.com", "user@example.com"),
+        ("user+a+b@example.com", "user@example.com"),
+        ("USER+Tag@Example.COM", "user@example.com"),
+        ("user+@example.com", "user@example.com"),
+    ],
+)
+def test_normalize_plus(raw, expected):
+    assert _normalize_plus(raw) == expected
+
+
+def test_normalize_plus_leaves_a_plus_in_the_domain_alone():
+    """Only the local part is aliased; the domain is untouched."""
+    assert _normalize_plus("user@ex+ample.com") == "user@ex+ample.com"
+
+
+# ---------------------------------------------------------------------------
+# The customer/email precondition
+# ---------------------------------------------------------------------------
+
+
+def test_context_is_built_for_an_event_with_a_customer_email():
+    wc = require_webhook_customer_context(fake_event())
+    assert isinstance(wc, WebhookContext)
+    assert wc.customer_email == "john.doe@email.com"
+    assert wc.event_context == "Webhook: customer.updated | Event ID: evt_1"
+    assert wc.ctx == "[Webhook: customer.updated | Event ID: evt_1] "
+
+
+def test_no_context_without_a_customer():
+    assert require_webhook_customer_context(fake_event(email=None)) is None
+
+
+def test_no_context_without_an_email():
+    assert require_webhook_customer_context(fake_event(email="")) is None
+
+
+def test_the_invalid_case_can_be_logged_on_request():
+    with patch("backend.apps.account_payment.webhooks.logger") as logger:
+        assert require_webhook_customer_context(fake_event(email=None), log_if_invalid=True) is None
+        logger.warning.assert_called_once()
+
+
+def test_the_invalid_case_is_silent_by_default():
+    with patch("backend.apps.account_payment.webhooks.logger") as logger:
+        require_webhook_customer_context(fake_event(email=None))
+        logger.warning.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Account lookup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_the_account_is_found_by_the_customer_email(account):
+    assert get_account_for_stripe_customer(fake_event()) == account
+
+
+@pytest.mark.django_db
+def test_an_unknown_customer_email_yields_no_account(account):
+    assert get_account_for_stripe_customer(fake_event(email="nobody@email.com")) is None
+
+
+# ---------------------------------------------------------------------------
+# Product resolution
+# ---------------------------------------------------------------------------
+
+
+def test_product_slug_comes_from_the_subscriptions_plan():
+    subscription = SimpleNamespace(
+        subscription=SimpleNamespace(plan=SimpleNamespace(product=product("chatbot")))
+    )
+    assert get_product_slug(subscription) == "chatbot"
+
+
+def test_product_slug_falls_back_to_the_first_line_item():
+    dj_sub = SimpleNamespace(
+        plan=None,
+        items=SimpleNamespace(
+            first=lambda: SimpleNamespace(price=SimpleNamespace(product=product("bd_pro")))
+        ),
+    )
+    assert get_product_slug(SimpleNamespace(subscription=dj_sub)) == "bd_pro"
+
+
+def test_product_slug_is_empty_when_nothing_resolves():
+    assert get_product_slug(None, None) == ""
+    assert get_product_slug(SimpleNamespace(subscription=None), None) == ""
+
+
+def test_product_slug_is_empty_rather_than_raising():
+    class Exploding:
+        @property
+        def subscription(self):
+            raise RuntimeError("stripe is down")
+
+    assert get_product_slug(Exploding()) == ""
+
+
+@pytest.mark.django_db
+def test_product_slug_from_the_event_when_the_subscription_has_none():
+    """With no internal subscription the event's own id is looked up instead."""
+    event = fake_event(object_id="sub_abc")
+    with patch("backend.apps.account_payment.webhooks.DJStripeSubscription") as dj_subscription:
+        dj_subscription.objects.filter.return_value.first.return_value = SimpleNamespace(
+            plan=SimpleNamespace(product=product("chatbot"))
+        )
+        assert get_product_slug(None, event) == "chatbot"
+        dj_subscription.objects.filter.assert_called_once_with(id="sub_abc")
+
+
+def test_subscription_product_is_chatbot_wraps_the_slug_check():
+    chatbot = SimpleNamespace(
+        subscription=SimpleNamespace(plan=SimpleNamespace(product=product("chatbot")))
+    )
+    bd_pro = SimpleNamespace(
+        subscription=SimpleNamespace(plan=SimpleNamespace(product=product("bd_pro")))
+    )
+    assert subscription_product_is_chatbot(chatbot, None, "ctx") is True
+    assert subscription_product_is_chatbot(bd_pro, None, "ctx") is False
+    assert subscription_product_is_chatbot(None, None, "ctx") is False
+
+
+# ---------------------------------------------------------------------------
+# get_subscription
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_subscription_needs_an_object_id():
+    event = fake_event()
+    event.data = {"object": {}}
+    assert get_subscription(event) is None
+
+
+@pytest.mark.django_db
+def test_get_subscription_returns_none_for_an_unknown_stripe_subscription():
+    assert get_subscription(fake_event(object_id="sub_missing")) is None
+
+
+# ---------------------------------------------------------------------------
+# Chatbot access, and the admin guard
+# ---------------------------------------------------------------------------
+
+
+def context():
+    return WebhookContext(
+        event=fake_event(), event_context="ctx", ctx="[ctx] ", customer_email="john.doe@email.com"
+    )
+
+
+@pytest.mark.django_db
+def test_chatbot_access_is_granted(account):
+    _set_account_chatbot_access(account, True, context(), "granting")
+    account.refresh_from_db()
+    assert account.has_chatbot_access is True
+
+
+@pytest.mark.django_db
+def test_chatbot_access_is_revoked(account):
+    account.has_chatbot_access = True
+    account.save()
+    _set_account_chatbot_access(account, False, context(), "revoking")
+    account.refresh_from_db()
+    assert account.has_chatbot_access is False
+
+
+@pytest.mark.django_db
+def test_an_admin_never_loses_chatbot_access_to_a_webhook(account):
+    """A lapsed Stripe subscription must not lock a staff member out."""
+    account.is_admin = True
+    account.has_chatbot_access = True
+    account.save()
+    _set_account_chatbot_access(account, False, context(), "revoking")
+    account.refresh_from_db()
+    assert account.has_chatbot_access is True
+
+
+@pytest.mark.django_db
+def test_an_admin_can_still_be_granted_access(account):
+    account.is_admin = True
+    account.save()
+    _set_account_chatbot_access(account, True, context(), "granting")
+    account.refresh_from_db()
+    assert account.has_chatbot_access is True

--- a/backend/apps/account_payment/tests.gql
+++ b/backend/apps/account_payment/tests.gql
@@ -55,12 +55,10 @@ mutation UpdateStripeCustomer {
   }
 }
 
-mutation CreateStripeSubscription {
-  createStripeSubscription(priceId: 1) {
-    subscription {
-      id
-      clientSecret
-    }
+mutation CreateStripeSubscription($priceId: ID!) {
+  createStripeSubscription(priceId: $priceId) {
+    clientSecret
+    errors
   }
 }
 

--- a/backend/apps/account_payment/tests.py
+++ b/backend/apps/account_payment/tests.py
@@ -15,17 +15,23 @@ QUERY = (
     .with_name("tests.gql")
     .read_text()
 )  # fmt: skip
-GRAPHQL_URL = "/api/graphql/"
+GRAPHQL_URL = "/api/v1/graphql"
 
 
 @pytest.fixture
 def account():
-    return Account.objects.create(
-        is_active=True,
+    # create_user hashes the password; Account.objects.create would store it verbatim
+    # and the login mutation below would never authenticate.
+    account = Account.objects.create_user(
         username="john.doe",
         password="12345678",
         email="john.doe@email.com",
+        first_name="John",
+        last_name="Doe",
     )
+    account.is_active = True
+    account.save()
+    return account
 
 
 @pytest.fixture
@@ -75,8 +81,8 @@ def test_all_stripe_price_call(query):
 
 
 @pytest.mark.django_db
-@patch("backend.apps.payment.graphql.StripeCustomer")
-@patch("backend.apps.payment.graphql.DJStripeCustomer")
+@patch("backend.apps.account_payment.graphql.StripeCustomer")
+@patch("backend.apps.account_payment.graphql.DJStripeCustomer")
 def test_create_stripe_customer_call(
     djst_customer: MagicMock, strp_customer: MagicMock, query, account
 ):
@@ -86,7 +92,7 @@ def test_create_stripe_customer_call(
 
 
 @pytest.mark.django_db
-@patch("backend.apps.payment.graphql.StripeCustomer")
+@patch("backend.apps.account_payment.graphql.StripeCustomer")
 def test_update_stripe_customer_call(strp_customer: MagicMock, query, account, customer):
     query("UpdateStripeCustomer")
     strp_customer.modify.assert_called_once()

--- a/backend/apps/admin_data_tools/tests.py
+++ b/backend/apps/admin_data_tools/tests.py
@@ -1,3 +1,316 @@
 # -*- coding: utf-8 -*-
+"""Tests for the Prefect flow-failure webhook.
 
-# Create your tests here.
+This endpoint decides whether a pipeline's schedule gets switched off. Both
+failure modes matter: disabling a healthy flow stops data updating, and failing
+to disable a broken one leaves it retrying indefinitely. The reactivated_at
+guard exists so that an admin who fixes and re-enables a flow does not have it
+immediately re-disabled by the failures that preceded the fix.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test.client import Client
+
+from backend.apps.admin_data_tools.models import DisabledFlowSchedule
+from backend.apps.admin_data_tools.views import (
+    _after_reactivation,
+    _check_bearer_token,
+    _is_consecutive_failure,
+    _is_dbt_failure,
+    _is_dbt_task,
+)
+
+NOW = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+TOKEN = "test-prefect-key"
+WEBHOOK = "/admin-tools/flow-failed/"
+
+HEARTBEAT = "No heartbeat detected from the remote task; marking the run as failed."
+
+
+def iso(dt):
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def run(state="Failed", at=NOW):
+    return {"state_name": state, "start_time": iso(at)}
+
+
+# ---------------------------------------------------------------------------
+# Task name matching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["run_dbt", "run_dbt-9da", "run_dbt-abc123"])
+def test_prefect_hash_suffixes_still_match(name):
+    assert _is_dbt_task(name) is True
+
+
+@pytest.mark.parametrize("name", ["run_dbt_extra", "rundbt", "run_dbtx", "", "dbt"])
+def test_other_task_names_do_not_match(name):
+    assert _is_dbt_task(name) is False
+
+
+# ---------------------------------------------------------------------------
+# The reactivation guard
+# ---------------------------------------------------------------------------
+
+
+def test_without_a_reactivation_date_every_run_counts():
+    assert _after_reactivation(iso(NOW), None) is True
+
+
+def test_a_run_after_reactivation_counts():
+    assert _after_reactivation(iso(NOW), NOW - timedelta(hours=1)) is True
+
+
+def test_a_run_before_reactivation_does_not_count():
+    assert _after_reactivation(iso(NOW), NOW + timedelta(hours=1)) is False
+
+
+def test_a_run_exactly_at_reactivation_does_not_count():
+    """Strictly after, so the boundary is excluded."""
+    assert _after_reactivation(iso(NOW), NOW) is False
+
+
+def test_a_zulu_timestamp_is_parsed():
+    assert _after_reactivation("2026-06-01T12:00:00Z", NOW - timedelta(days=1)) is True
+
+
+# ---------------------------------------------------------------------------
+# dbt failures
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_dbt_task_is_a_dbt_failure():
+    tasks = [{"name": "run_dbt", "state_message": "compilation error"}]
+    assert _is_dbt_failure(tasks, iso(NOW), None) is True
+
+
+def test_a_heartbeat_timeout_is_not_a_dbt_failure():
+    """Infrastructure flakiness must not switch off a schedule."""
+    tasks = [{"name": "run_dbt", "state_message": HEARTBEAT}]
+    assert _is_dbt_failure(tasks, iso(NOW), None) is False
+
+
+def test_a_non_dbt_task_failure_is_not_a_dbt_failure():
+    tasks = [{"name": "upload_to_gcs", "state_message": "boom"}]
+    assert _is_dbt_failure(tasks, iso(NOW), None) is False
+
+
+def test_no_failed_tasks_is_not_a_dbt_failure():
+    assert _is_dbt_failure([], iso(NOW), None) is False
+
+
+def test_a_dbt_failure_before_reactivation_is_ignored():
+    tasks = [{"name": "run_dbt", "state_message": "compilation error"}]
+    assert _is_dbt_failure(tasks, iso(NOW), NOW + timedelta(hours=1)) is False
+
+
+def test_one_real_dbt_failure_among_ignorable_ones_still_counts():
+    tasks = [
+        {"name": "run_dbt", "state_message": HEARTBEAT},
+        {"name": "run_dbt-9da", "state_message": "compilation error"},
+    ]
+    assert _is_dbt_failure(tasks, iso(NOW), None) is True
+
+
+# ---------------------------------------------------------------------------
+# Consecutive failures
+# ---------------------------------------------------------------------------
+
+
+def test_two_failures_in_a_row_count():
+    assert _is_consecutive_failure([run("Failed"), run("Failed")], None) is True
+
+
+def test_a_crash_counts_as_a_failure():
+    assert _is_consecutive_failure([run("Crashed"), run("Failed")], None) is True
+
+
+def test_a_success_in_either_slot_breaks_the_streak():
+    assert _is_consecutive_failure([run("Completed"), run("Failed")], None) is False
+    assert _is_consecutive_failure([run("Failed"), run("Completed")], None) is False
+
+
+def test_fewer_than_two_runs_is_not_a_streak():
+    assert _is_consecutive_failure([], None) is False
+    assert _is_consecutive_failure([run("Failed")], None) is False
+
+
+def test_a_streak_from_before_reactivation_is_ignored():
+    runs = [run("Failed", NOW), run("Failed", NOW - timedelta(hours=1))]
+    assert _is_consecutive_failure(runs, NOW + timedelta(hours=1)) is False
+
+
+# ---------------------------------------------------------------------------
+# The bearer token guard
+# ---------------------------------------------------------------------------
+
+
+def request_with(auth):
+    return MagicMock(META={"HTTP_AUTHORIZATION": auth} if auth is not None else {})
+
+
+def test_the_matching_bearer_token_is_accepted(monkeypatch):
+    monkeypatch.setenv("PREFECT3_API_KEY", TOKEN)
+    assert _check_bearer_token(request_with(f"Bearer {TOKEN}")) is True
+
+
+@pytest.mark.parametrize("auth", ["Bearer wrong", TOKEN, "", None, "Basic x"])
+def test_anything_else_is_rejected(monkeypatch, auth):
+    monkeypatch.setenv("PREFECT3_API_KEY", TOKEN)
+    assert _check_bearer_token(request_with(auth)) is False
+
+
+def test_an_unset_server_key_rejects_everything(monkeypatch):
+    """An empty expected key must never authorise a request."""
+    monkeypatch.setenv("PREFECT3_API_KEY", "")
+    assert _check_bearer_token(request_with("Bearer ")) is False
+    assert _check_bearer_token(request_with("")) is False
+
+
+# ---------------------------------------------------------------------------
+# The webhook endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="api_key")
+def fixture_api_key(monkeypatch):
+    monkeypatch.setenv("PREFECT3_API_KEY", TOKEN)
+    return TOKEN
+
+
+@pytest.fixture(name="record")
+def fixture_record():
+    return DisabledFlowSchedule.objects.create(
+        flow_name="br_ms_sia",
+        deployment_id="dep-1",
+        is_schedule_active=True,
+    )
+
+
+def post(client, payload, *, token=TOKEN):
+    headers = {"HTTP_AUTHORIZATION": f"Bearer {token}"} if token else {}
+    return client.post(
+        WEBHOOK, data=json.dumps(payload), content_type="application/json", **headers
+    )
+
+
+@pytest.mark.django_db
+def test_the_webhook_requires_a_token(client: Client, api_key):
+    assert post(client, {}, token=None).status_code == 401
+
+
+@pytest.mark.django_db
+def test_the_webhook_rejects_a_wrong_token(client: Client, api_key):
+    assert post(client, {}, token="wrong").status_code == 401
+
+
+@pytest.mark.django_db
+def test_the_webhook_rejects_invalid_json(client: Client, api_key):
+    response = client.post(
+        WEBHOOK,
+        data="not json",
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {TOKEN}",
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_the_webhook_requires_both_ids(client: Client, api_key):
+    assert post(client, {"deployment_id": "dep-1"}).status_code == 400
+    assert post(client, {"flow_run_id": "run-1"}).status_code == 400
+
+
+@pytest.mark.django_db
+def test_an_unknown_deployment_is_ignored(client: Client, api_key):
+    response = post(client, {"deployment_id": "unknown", "flow_run_id": "run-1"})
+    assert response.json() == {"status": "ok", "action": "ignored_unknown"}
+
+
+@pytest.mark.django_db
+def test_an_already_paused_flow_is_left_alone(client: Client, api_key, record):
+    record.is_schedule_active = False
+    record.save()
+    response = post(client, {"deployment_id": "dep-1", "flow_run_id": "run-1"})
+    assert response.json() == {"status": "ok", "action": "already_paused"}
+
+
+@pytest.mark.django_db
+@patch("backend.apps.admin_data_tools.views.Prefect3Client")
+def test_two_consecutive_failures_disable_the_schedule(
+    client_cls: MagicMock, client: Client, api_key, record
+):
+    prefect = client_cls.return_value
+    prefect.get_recent_completed_runs.return_value = [run("Failed"), run("Failed")]
+    prefect.get_failed_task_runs.return_value = []
+
+    response = post(client, {"deployment_id": "dep-1", "flow_run_id": "run-1"})
+
+    assert response.json() == {"status": "ok", "action": "disabled"}
+    prefect.set_paused.assert_called_once_with("dep-1", paused=True)
+    record.refresh_from_db()
+    assert record.is_schedule_active is False
+    assert record.reactivated_at is None
+    assert record.disabled_at is not None
+
+
+@pytest.mark.django_db
+@patch("backend.apps.admin_data_tools.views.Prefect3Client")
+def test_a_single_dbt_failure_disables_the_schedule(
+    client_cls: MagicMock, client: Client, api_key, record
+):
+    prefect = client_cls.return_value
+    prefect.get_recent_completed_runs.return_value = [run("Failed"), run("Completed")]
+    prefect.get_failed_task_runs.return_value = [
+        {"name": "run_dbt", "state_message": "compilation error"}
+    ]
+
+    response = post(client, {"deployment_id": "dep-1", "flow_run_id": "run-1"})
+    assert response.json() == {"status": "ok", "action": "disabled"}
+
+
+@pytest.mark.django_db
+@patch("backend.apps.admin_data_tools.views.Prefect3Client")
+def test_an_isolated_non_dbt_failure_takes_no_action(
+    client_cls: MagicMock, client: Client, api_key, record
+):
+    prefect = client_cls.return_value
+    prefect.get_recent_completed_runs.return_value = [run("Failed"), run("Completed")]
+    prefect.get_failed_task_runs.return_value = [{"name": "upload", "state_message": "boom"}]
+
+    response = post(client, {"deployment_id": "dep-1", "flow_run_id": "run-1"})
+    assert response.json() == {"status": "ok", "action": "no_action"}
+    prefect.set_paused.assert_not_called()
+    record.refresh_from_db()
+    assert record.is_schedule_active is True
+
+
+@pytest.mark.django_db
+@patch("backend.apps.admin_data_tools.views.Prefect3Client")
+def test_failures_predating_a_reactivation_do_not_re_disable(
+    client_cls: MagicMock, client: Client, api_key, record
+):
+    """An admin fixed the flow and re-enabled it; the old failures must not undo that."""
+    record.reactivated_at = NOW + timedelta(hours=1)
+    record.save()
+    prefect = client_cls.return_value
+    prefect.get_recent_completed_runs.return_value = [run("Failed"), run("Failed")]
+    prefect.get_failed_task_runs.return_value = [
+        {"name": "run_dbt", "state_message": "compilation error"}
+    ]
+
+    response = post(client, {"deployment_id": "dep-1", "flow_run_id": "run-1"})
+    assert response.json() == {"status": "ok", "action": "no_action"}
+    record.refresh_from_db()
+    assert record.is_schedule_active is True
+
+
+@pytest.mark.django_db
+def test_the_model_is_named_by_its_flow(record):
+    assert str(record) == "br_ms_sia"

--- a/backend/apps/api/v1/models.py
+++ b/backend/apps/api/v1/models.py
@@ -77,9 +77,9 @@ class Area(BaseModel):
 
         if self.parent and self.parent.slug != "world":
             if self.administrative_level is None:
-                errors[
-                    "administrative_level"
-                ] = "Administrative level is required when parent is set"
+                errors["administrative_level"] = (
+                    "Administrative level is required when parent is set"
+                )
             elif self.parent.administrative_level is None:
                 errors["parent"] = "Parent must have an administrative level"
             elif self.parent.administrative_level != self.administrative_level - 1:
@@ -1029,7 +1029,7 @@ class Poll(BaseModel):
         errors = {}
         if bool(self.raw_data_source) == bool(self.information_request):
             raise ValidationError(
-                "One and only one of 'raw_data_source'," " or 'information_request' must be set."
+                "One and only one of 'raw_data_source', or 'information_request' must be set."
             )
         if self.entity and self.entity.category.slug != "datetime":
             errors["entity"] = 'Entity must have category "datetime"'
@@ -1675,13 +1675,13 @@ class Column(BaseModel, OrderedModel):
         """Clean method for Column model"""
         errors = {}
         if self.observation_level and self.observation_level.table != self.table:
-            errors[
-                "observation_level"
-            ] = "Observation level is not in the same table as the column."
+            errors["observation_level"] = (
+                "Observation level is not in the same table as the column."
+            )
         if self.directory_primary_key and self.directory_primary_key.table.is_directory is False:
-            errors[
-                "directory_primary_key"
-            ] = "Column indicated as a directory's primary key is not in a directory."
+            errors["directory_primary_key"] = (
+                "Column indicated as a directory's primary key is not in a directory."
+            )
         if errors:
             raise ValidationError(errors)
         return super().clean()
@@ -1767,7 +1767,7 @@ class CloudTable(BaseModel):
         errors = {}
         if self.gcp_project_id and not check_kebab_case(self.gcp_project_id):
             errors["gcp_project_id"] = "gcp_project_id must be in kebab-case."
-        if self.gcp_project_id and not check_snake_case(self.gcp_dataset_id):
+        if self.gcp_dataset_id and not check_snake_case(self.gcp_dataset_id):
             errors["gcp_dataset_id"] = "gcp_dataset_id must be in snake_case."
         if self.gcp_table_id and not check_snake_case(self.gcp_table_id):
             errors["gcp_table_id"] = "gcp_table_id must be in snake_case."

--- a/backend/apps/api/v1/tests/test_area.py
+++ b/backend/apps/api/v1/tests/test_area.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""Tests for Area.clean().
+
+Area encodes the spatial hierarchy every coverage rolls up through, and its
+validation is the only thing keeping that hierarchy consistent.
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from backend.apps.api.v1.models import Area, Entity, EntityCategory
+
+
+@pytest.fixture(name="entity_spatial")
+def fixture_entity_spatial():
+    category = EntityCategory.objects.create(slug="spatial", name="Spatial")
+    return Entity.objects.create(slug="municipality", name="Município", category=category)
+
+
+@pytest.mark.django_db
+def test_area_without_parent_is_valid():
+    area = Area(slug="br", name="Brasil", administrative_level=0)
+    area.clean()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("level", [0, 1, 2, 3])
+def test_accepted_administrative_levels(level):
+    Area(slug=f"lvl{level}", name="Area", administrative_level=level).clean()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("level", [4, 5, -1])
+def test_rejected_administrative_levels(level):
+    """The field offers 0-5 as choices but clean() only accepts 0-3."""
+    area = Area(slug="area", name="Area", administrative_level=level)
+    with pytest.raises(ValidationError) as exc:
+        area.clean()
+    assert "administrative_level" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_entity_must_be_spatial(entity_anual):
+    """entity_anual belongs to the "time" category."""
+    area = Area(slug="br", name="Brasil", administrative_level=0, entity=entity_anual)
+    with pytest.raises(ValidationError) as exc:
+        area.clean()
+    assert "entity" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_spatial_entity_is_accepted(entity_spatial):
+    Area(slug="br", name="Brasil", administrative_level=0, entity=entity_spatial).clean()
+
+
+@pytest.mark.django_db
+def test_parent_requires_an_administrative_level():
+    parent = Area.objects.create(slug="br", name="Brasil", administrative_level=0)
+    area = Area(slug="br_mg", name="Minas Gerais", parent=parent)
+    with pytest.raises(ValidationError) as exc:
+        area.clean()
+    assert "administrative_level" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_parent_must_have_an_administrative_level():
+    parent = Area.objects.create(slug="br", name="Brasil")
+    area = Area(slug="br_mg", name="Minas Gerais", administrative_level=1, parent=parent)
+    with pytest.raises(ValidationError) as exc:
+        area.clean()
+    assert "parent" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_parent_must_be_exactly_one_level_above():
+    parent = Area.objects.create(slug="br", name="Brasil", administrative_level=0)
+    area = Area(slug="br_mg_3100104", name="Belo Horizonte", administrative_level=2, parent=parent)
+    with pytest.raises(ValidationError) as exc:
+        area.clean()
+    assert "parent" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_valid_parent_child_pair():
+    parent = Area.objects.create(slug="br", name="Brasil", administrative_level=0)
+    Area(slug="br_mg", name="Minas Gerais", administrative_level=1, parent=parent).clean()
+
+
+@pytest.mark.django_db
+def test_world_parent_skips_the_level_check():
+    """ "world" is the hierarchy root and is exempt from the level relationship."""
+    world = Area.objects.create(slug="world", name="Mundo")
+    Area(slug="br", name="Brasil", administrative_level=0, parent=world).clean()
+
+
+@pytest.mark.django_db
+def test_str_includes_name_and_slug():
+    area = Area(slug="br_mg", name="Minas Gerais")
+    assert str(area) == "Minas Gerais (br_mg)"

--- a/backend/apps/api/v1/tests/test_cloud_table.py
+++ b/backend/apps/api/v1/tests/test_cloud_table.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""Tests for CloudTable validation and the Table slug properties derived from it."""
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from backend.apps.api.v1.models import CloudTable
+
+
+def build(table, **overrides):
+    fields = {
+        "table": table,
+        "gcp_project_id": "basedosdados-dev",
+        "gcp_dataset_id": "mundo_transferwise",
+        "gcp_table_id": "taxa_cambio",
+    }
+    fields.update(overrides)
+    return CloudTable.objects.create(**fields)
+
+
+@pytest.mark.django_db
+def test_valid_identifiers_pass(tabela_bairros):
+    cloud_table = build(tabela_bairros)
+    cloud_table.clean()
+    assert str(cloud_table) == "basedosdados-dev.mundo_transferwise.taxa_cambio"
+
+
+@pytest.mark.django_db
+def test_project_id_must_be_kebab_case(tabela_bairros):
+    cloud_table = build(tabela_bairros, gcp_project_id="base_dos_dados")
+    with pytest.raises(ValidationError) as exc:
+        cloud_table.clean()
+    assert "gcp_project_id" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_dataset_id_must_be_snake_case(tabela_bairros):
+    cloud_table = build(tabela_bairros, gcp_dataset_id="mundo-transferwise")
+    with pytest.raises(ValidationError) as exc:
+        cloud_table.clean()
+    assert "gcp_dataset_id" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_table_id_must_be_snake_case(tabela_bairros):
+    cloud_table = build(tabela_bairros, gcp_table_id="Taxa-Cambio")
+    with pytest.raises(ValidationError) as exc:
+        cloud_table.clean()
+    assert "gcp_table_id" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_dataset_id_is_validated_even_without_a_project_id(tabela_bairros):
+    """Each identifier is guarded by its own value.
+
+    The dataset check previously keyed off gcp_project_id, so a malformed dataset
+    id passed validation whenever the project id happened to be blank.
+    """
+    cloud_table = build(tabela_bairros, gcp_project_id="", gcp_dataset_id="Mundo-Transferwise")
+    with pytest.raises(ValidationError) as exc:
+        cloud_table.clean()
+    assert "gcp_dataset_id" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_blank_identifiers_are_skipped(tabela_bairros):
+    """Blank is handled by the field's own required/blank rules, not by the case check."""
+    cloud_table = build(tabela_bairros, gcp_project_id="", gcp_dataset_id="", gcp_table_id="")
+    cloud_table.clean()
+
+
+@pytest.mark.django_db
+def test_columns_must_belong_to_the_same_table(tabela_bairros, tabela_pro, coluna_nome_bairros):
+    cloud_table = build(tabela_pro)
+    cloud_table.columns.add(coluna_nome_bairros)
+    with pytest.raises(ValidationError) as exc:
+        cloud_table.clean()
+    assert "columns" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_all_errors_are_reported_together(tabela_bairros):
+    cloud_table = build(
+        tabela_bairros,
+        gcp_project_id="Base_Dos_Dados",
+        gcp_dataset_id="Mundo-Transferwise",
+        gcp_table_id="Taxa-Cambio",
+    )
+    with pytest.raises(ValidationError) as exc:
+        cloud_table.clean()
+    assert set(exc.value.message_dict) == {
+        "gcp_project_id",
+        "gcp_dataset_id",
+        "gcp_table_id",
+    }
+
+
+@pytest.mark.django_db
+def test_table_slugs_derive_from_the_first_cloud_table(tabela_bairros):
+    build(tabela_bairros)
+    assert tabela_bairros.gbq_slug == "basedosdados.mundo_transferwise.taxa_cambio"
+    assert tabela_bairros.gbq_dict_slug == "basedosdados.mundo_transferwise.dicionario"
+    assert tabela_bairros.gbq_table_slug == "taxa_cambio"
+    assert tabela_bairros.gcs_slug == "staging/mundo_transferwise/taxa_cambio"
+
+
+@pytest.mark.django_db
+def test_table_slugs_are_none_without_a_cloud_table(tabela_bairros):
+    assert tabela_bairros.gbq_slug is None
+    assert tabela_bairros.gbq_dict_slug is None
+    assert tabela_bairros.gbq_table_slug is None
+    assert tabela_bairros.gcs_slug is None

--- a/backend/apps/api/v1/tests/test_column_coverage.py
+++ b/backend/apps/api/v1/tests/test_column_coverage.py
@@ -2,7 +2,6 @@
 """
 Pytest Django models tests.
 """
-import json
 
 import pytest
 
@@ -31,11 +30,8 @@ def test_column_coverage_with_empty_date_time_range(
     datetime_range_empty.coverage = coverage_coluna_open
     datetime_range_empty.save()
 
-    tabela_full_coverage = json.loads(tabela_bairros.full_coverage)
-    coluna_full_coverage = json.loads(coluna_nome_bairros.full_coverage)
-
-    assert tabela_full_coverage[0]["year"] == "2021"
-    assert coluna_full_coverage[0]["year"] == "2021"
+    assert tabela_bairros.temporal_coverage == {"start": "2021-06", "end": "2023-06"}
+    assert coluna_nome_bairros.temporal_coverage == {"start": "2021-06", "end": "2023-06"}
 
 
 @pytest.mark.django_db
@@ -53,11 +49,8 @@ def test_column_coverage_with_no_date_time_range(
     datetime_range_1.save()
     coverage_tabela_open.datetime_ranges.add(datetime_range_1)
 
-    tabela_full_coverage = json.loads(tabela_bairros.full_coverage)
-    coluna_full_coverage = json.loads(coluna_nome_bairros.full_coverage)
-
-    assert tabela_full_coverage[0]["year"] == "2021"
-    assert coluna_full_coverage[0]["year"] == "2021"
+    assert tabela_bairros.temporal_coverage == {"start": "2021-06", "end": "2023-06"}
+    assert coluna_nome_bairros.temporal_coverage == {"start": "2021-06", "end": "2023-06"}
 
 
 @pytest.mark.django_db
@@ -72,7 +65,7 @@ def test_column_coverage_with_date_time_range(
     """
     Test for inheritance of column coverage. The table has a datetime_range coverage,
     and the data in column datetime_range is set.
-    In this case, full_coverage must return the column coverage.
+    In this case, temporal_coverage must return the column coverage.
     """
     # creates a coverage for the table, add a datetime_range for the table
     # and add the datetime_range to the column coverage
@@ -84,8 +77,5 @@ def test_column_coverage_with_date_time_range(
     datetime_range_2.save()
     coverage_coluna_open.datetime_ranges.add(datetime_range_2)
 
-    tabela_full_coverage = json.loads(tabela_bairros.full_coverage)
-    coluna_full_coverage = json.loads(coluna_nome_bairros.full_coverage)
-
-    assert tabela_full_coverage[0]["year"] == "2021"
-    assert coluna_full_coverage[0]["year"] == "2022"
+    assert tabela_bairros.temporal_coverage == {"start": "2021-06", "end": "2023-06"}
+    assert coluna_nome_bairros.temporal_coverage == {"start": "2022-06", "end": "2024-06"}

--- a/backend/apps/api/v1/tests/test_dataset_aggregates.py
+++ b/backend/apps/api/v1/tests/test_dataset_aggregates.py
@@ -1,0 +1,320 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Dataset aggregate properties.
+
+Every one of these properties rolls up the dataset's tables while excluding two
+things: tables whose status is under_review or excluded, and the dictionary
+tables (slug "dicionario" or "dictionary"). That exclusion is written out
+longhand in roughly fifteen places, so it is exactly the kind of rule that drifts
+in one copy without anyone noticing. These tests pin it down.
+
+Dataset caches its table queryset with cached_property, so each test reloads the
+dataset before reading a property.
+"""
+
+import pytest
+
+from backend.apps.api.v1.models import (
+    Coverage,
+    Dataset,
+    InformationRequest,
+    RawDataSource,
+    Status,
+    Table,
+)
+
+MB = 1024 * 1024
+
+
+@pytest.fixture(name="status_excluded")
+def fixture_status_excluded():
+    return Status.objects.create(name="Excluído", slug="excluded")
+
+
+@pytest.fixture(name="status_under_review")
+def fixture_status_under_review():
+    return Status.objects.create(name="Em revisão", slug="under_review")
+
+
+def add_table(dataset, slug, *, status=None, size=None, order=0, **kwargs):
+    return Table.objects.create(
+        dataset=dataset,
+        slug=slug,
+        name=slug,
+        status=status,
+        uncompressed_file_size=size,
+        order=order,
+        **kwargs,
+    )
+
+
+def reload(dataset):
+    """Return a fresh instance, since the aggregates cache their queryset."""
+    return Dataset.objects.get(pk=dataset.pk)
+
+
+# ---------------------------------------------------------------------------
+# The exclusion rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_counts_only_visible_tables(dataset_dados_mestres, status_excluded, status_under_review):
+    add_table(dataset_dados_mestres, "visivel")
+    add_table(dataset_dados_mestres, "excluida", status=status_excluded)
+    add_table(dataset_dados_mestres, "em_revisao", status=status_under_review)
+    assert reload(dataset_dados_mestres).n_tables == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("slug", ["dicionario", "dictionary"])
+def test_dictionary_tables_are_excluded(dataset_dados_mestres, slug):
+    add_table(dataset_dados_mestres, "visivel")
+    add_table(dataset_dados_mestres, slug)
+    assert reload(dataset_dados_mestres).n_tables == 1
+
+
+@pytest.mark.django_db
+def test_contains_tables_is_false_when_only_excluded_tables_exist(
+    dataset_dados_mestres, status_excluded
+):
+    add_table(dataset_dados_mestres, "excluida", status=status_excluded)
+    add_table(dataset_dados_mestres, "dicionario")
+    dataset = reload(dataset_dados_mestres)
+    assert dataset.contains_tables is False
+    assert dataset.n_tables == 0
+
+
+@pytest.mark.django_db
+def test_contains_tables_is_true_with_one_visible_table(dataset_dados_mestres):
+    add_table(dataset_dados_mestres, "visivel")
+    assert reload(dataset_dados_mestres).contains_tables is True
+
+
+@pytest.mark.django_db
+def test_empty_dataset_reports_nothing(dataset_dados_mestres):
+    dataset = reload(dataset_dados_mestres)
+    assert dataset.contains_tables is False
+    assert dataset.contains_raw_data_sources is False
+    assert dataset.contains_information_requests is False
+    assert dataset.n_tables == 0
+    assert dataset.n_raw_data_sources == 0
+    assert dataset.n_information_requests == 0
+    assert dataset.first_table_id is None
+    assert dataset.first_raw_data_source_id is None
+    assert dataset.first_information_request_id is None
+
+
+# ---------------------------------------------------------------------------
+# Open and closed data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_contains_open_data_follows_table_coverage(dataset_dados_mestres, area_br):
+    table = add_table(dataset_dados_mestres, "aberta")
+    Coverage.objects.create(table=table, area=area_br, is_closed=False)
+    dataset = reload(dataset_dados_mestres)
+    assert dataset.contains_open_data is True
+    assert dataset.contains_closed_data is False
+
+
+@pytest.mark.django_db
+def test_contains_closed_data_follows_table_coverage(dataset_dados_mestres, area_br):
+    table = add_table(dataset_dados_mestres, "fechada")
+    Coverage.objects.create(table=table, area=area_br, is_closed=True)
+    dataset = reload(dataset_dados_mestres)
+    assert dataset.contains_closed_data is True
+    assert dataset.contains_open_data is False
+
+
+@pytest.mark.django_db
+def test_open_data_on_an_excluded_table_does_not_count(
+    dataset_dados_mestres, area_br, status_excluded
+):
+    table = add_table(dataset_dados_mestres, "excluida", status=status_excluded)
+    Coverage.objects.create(table=table, area=area_br, is_closed=False)
+    assert reload(dataset_dados_mestres).contains_open_data is False
+
+
+@pytest.mark.django_db
+def test_open_data_on_a_dictionary_table_does_not_count(dataset_dados_mestres, area_br):
+    table = add_table(dataset_dados_mestres, "dicionario")
+    Coverage.objects.create(table=table, area=area_br, is_closed=False)
+    assert reload(dataset_dados_mestres).contains_open_data is False
+
+
+@pytest.mark.django_db
+def test_a_dataset_can_hold_both_open_and_closed_tables(dataset_dados_mestres, area_br):
+    aberta = add_table(dataset_dados_mestres, "aberta")
+    fechada = add_table(dataset_dados_mestres, "fechada", order=1)
+    Coverage.objects.create(table=aberta, area=area_br, is_closed=False)
+    Coverage.objects.create(table=fechada, area=area_br, is_closed=True)
+    dataset = reload(dataset_dados_mestres)
+    assert dataset.contains_open_data is True
+    assert dataset.contains_closed_data is True
+
+
+# ---------------------------------------------------------------------------
+# Direct download, which is decided by file size
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_direct_download_counts_split_on_the_100mb_threshold(dataset_dados_mestres):
+    add_table(dataset_dados_mestres, "pequena", size=50 * MB)
+    add_table(dataset_dados_mestres, "grande", size=500 * MB, order=1)
+    dataset = reload(dataset_dados_mestres)
+    assert dataset.contains_direct_download_free == 1
+    assert dataset.contains_direct_download_paid == 1
+
+
+@pytest.mark.django_db
+def test_a_table_without_a_size_counts_as_neither(dataset_dados_mestres):
+    add_table(dataset_dados_mestres, "sem_tamanho", size=None)
+    dataset = reload(dataset_dados_mestres)
+    assert dataset.contains_direct_download_free == 0
+    assert dataset.contains_direct_download_paid == 0
+
+
+@pytest.mark.django_db
+def test_a_large_table_is_closed_data(dataset_dados_mestres):
+    """Between 100 MB and 1 GB a table counts as closed on size alone."""
+    add_table(dataset_dados_mestres, "grande", size=500 * MB)
+    assert reload(dataset_dados_mestres).contains_closed_data is True
+
+
+# ---------------------------------------------------------------------------
+# first_* pointers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_first_table_id_follows_order(dataset_dados_mestres):
+    segunda = add_table(dataset_dados_mestres, "segunda", order=1)
+    primeira = add_table(dataset_dados_mestres, "primeira", order=0)
+    assert reload(dataset_dados_mestres).first_table_id == primeira.pk
+    assert segunda.pk != primeira.pk
+
+
+@pytest.mark.django_db
+def test_first_table_id_skips_excluded_tables(dataset_dados_mestres, status_excluded):
+    add_table(dataset_dados_mestres, "excluida", status=status_excluded, order=0)
+    visivel = add_table(dataset_dados_mestres, "visivel", order=1)
+    assert reload(dataset_dados_mestres).first_table_id == visivel.pk
+
+
+@pytest.mark.django_db
+def test_first_open_and_closed_table_ids(dataset_dados_mestres, area_br):
+    fechada = add_table(dataset_dados_mestres, "fechada", order=0)
+    aberta = add_table(dataset_dados_mestres, "aberta", order=1)
+    Coverage.objects.create(table=fechada, area=area_br, is_closed=True)
+    Coverage.objects.create(table=aberta, area=area_br, is_closed=False)
+    dataset = reload(dataset_dados_mestres)
+    assert dataset.first_open_table_id == aberta.pk
+    assert dataset.first_closed_table_id == fechada.pk
+
+
+@pytest.mark.django_db
+def test_first_open_table_id_is_none_without_open_data(dataset_dados_mestres, area_br):
+    fechada = add_table(dataset_dados_mestres, "fechada")
+    Coverage.objects.create(table=fechada, area=area_br, is_closed=True)
+    assert reload(dataset_dados_mestres).first_open_table_id is None
+
+
+# ---------------------------------------------------------------------------
+# Raw data sources and information requests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_raw_data_sources_are_counted_and_filtered(
+    dataset_dados_mestres, disponibilidade_online, licenca_mit, status_excluded
+):
+    visivel = RawDataSource.objects.create(
+        dataset=dataset_dados_mestres,
+        availability=disponibilidade_online,
+        license=licenca_mit,
+        name="visivel",
+        order=0,
+    )
+    RawDataSource.objects.create(
+        dataset=dataset_dados_mestres,
+        availability=disponibilidade_online,
+        license=licenca_mit,
+        name="excluida",
+        status=status_excluded,
+        order=1,
+    )
+    dataset = reload(dataset_dados_mestres)
+    assert dataset.n_raw_data_sources == 1
+    assert dataset.contains_raw_data_sources is True
+    assert dataset.first_raw_data_source_id == visivel.pk
+
+
+@pytest.mark.django_db
+def test_information_requests_are_counted_and_filtered(
+    dataset_dados_mestres, usuario_inicio, status_excluded
+):
+    visivel = InformationRequest.objects.create(
+        dataset=dataset_dados_mestres, started_by=usuario_inicio, order=0
+    )
+    InformationRequest.objects.create(
+        dataset=dataset_dados_mestres,
+        started_by=usuario_inicio,
+        status=status_excluded,
+        order=1,
+    )
+    dataset = reload(dataset_dados_mestres)
+    assert dataset.n_information_requests == 1
+    assert dataset.contains_information_requests is True
+    assert dataset.first_information_request_id == visivel.pk
+
+
+# ---------------------------------------------------------------------------
+# Slug, popularity, temporal coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_full_slug_is_prefixed_by_the_organization_area(dataset_dados_mestres):
+    assert dataset_dados_mestres.full_slug == "sa_br_dados_mestres"
+
+
+@pytest.mark.django_db
+def test_full_slug_drops_an_unknown_area(dataset_dados_mestres, organizacao_bd, area_br):
+    area_br.slug = "unknown"
+    area_br.save()
+    assert reload(dataset_dados_mestres).full_slug == "dados_mestres"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "page_views,expected",
+    [(0, 0.0), (None, 0.0), (1, 0.0), (10, 1.0), (100, 2.0), (1000, 3.0)],
+)
+def test_popularity_is_log10_of_page_views(dataset_dados_mestres, page_views, expected):
+    dataset_dados_mestres.page_views = page_views
+    assert dataset_dados_mestres.popularity == expected
+
+
+@pytest.mark.django_db
+def test_temporal_coverage_is_empty_without_ranges(dataset_dados_mestres):
+    add_table(dataset_dados_mestres, "sem_cobertura")
+    assert reload(dataset_dados_mestres).temporal_coverage == ""
+
+
+@pytest.mark.django_db
+def test_temporal_coverage_spans_the_datasets_tables(
+    dataset_dados_mestres, tabela_bairros, coverage_tabela_open, datetime_range_1
+):
+    datetime_range_1.coverage = coverage_tabela_open
+    datetime_range_1.save()
+    assert reload(dataset_dados_mestres).temporal_coverage == "2021-06 - 2023-06"
+
+
+@pytest.mark.django_db
+def test_spatial_coverage_unions_the_datasets_resources(
+    dataset_dados_mestres, tabela_bairros, area_br
+):
+    Coverage.objects.create(table=tabela_bairros, area=area_br, is_closed=False)
+    assert reload(dataset_dados_mestres).spatial_coverage == ["sa_br"]

--- a/backend/apps/api/v1/tests/test_model_validation.py
+++ b/backend/apps/api/v1/tests/test_model_validation.py
@@ -1,0 +1,283 @@
+# -*- coding: utf-8 -*-
+"""Tests for the model clean() validators.
+
+Coverage, Update, Poll and QualityCheck all enforce the same shape: exactly one
+of a set of mutually exclusive foreign keys must be set. The rule is spelled out
+separately in each model, so each copy is checked here.
+
+DateTimeRange gets its own section: its since/until properties assemble a
+datetime out of seven nullable integer columns, and everything temporal in the
+API is built on top of them.
+"""
+
+from datetime import datetime
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from backend.apps.api.v1.models import (
+    Coverage,
+    DateTimeRange,
+    Poll,
+    QualityCheck,
+    Update,
+)
+
+# ---------------------------------------------------------------------------
+# Coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_coverage_accepts_exactly_one_target(tabela_bairros):
+    Coverage(table=tabela_bairros).clean()
+
+
+@pytest.mark.django_db
+def test_coverage_rejects_no_target():
+    with pytest.raises(ValidationError):
+        Coverage().clean()
+
+
+@pytest.mark.django_db
+def test_coverage_rejects_two_targets(tabela_bairros, coluna_nome_bairros):
+    with pytest.raises(ValidationError):
+        Coverage(table=tabela_bairros, column=coluna_nome_bairros).clean()
+
+
+@pytest.mark.django_db
+def test_coverage_type_reports_the_target(tabela_bairros, coluna_nome_bairros, raw_data_source):
+    assert Coverage(table=tabela_bairros).coverage_type() == "table"
+    assert Coverage(column=coluna_nome_bairros).coverage_type() == "column"
+    assert Coverage(raw_data_source=raw_data_source).coverage_type() == "raw_data_source"
+    assert Coverage().coverage_type() == ""
+
+
+@pytest.mark.django_db
+def test_coverage_str_names_the_target(tabela_bairros, area_br):
+    coverage = Coverage(table=tabela_bairros, area=area_br)
+    assert str(coverage).startswith("Table: ")
+    assert str(tabela_bairros) in str(coverage)
+
+
+@pytest.mark.django_db
+def test_coverage_area_similarity(tabela_bairros, area_br):
+    """One area name being a prefix of the other counts as a match."""
+    from backend.apps.api.v1.models import Area
+
+    brasil = Area.objects.create(slug="br", name="Brasil")
+    brasil_mg = Area.objects.create(slug="br_mg", name="Brasil Minas Gerais")
+    outro = Area.objects.create(slug="ar", name="Argentina")
+
+    parent = Coverage(table=tabela_bairros, area=brasil)
+    child = Coverage(table=tabela_bairros, area=brasil_mg)
+    unrelated = Coverage(table=tabela_bairros, area=outro)
+    missing = Coverage(table=tabela_bairros)
+
+    assert parent.get_similarity_of_area(child) == 1
+    assert child.get_similarity_of_area(parent) == 1
+    assert parent.get_similarity_of_area(unrelated) == 0
+    assert parent.get_similarity_of_area(missing) == 0
+    assert missing.get_similarity_of_area(parent) == 0
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_update_accepts_exactly_one_target(tabela_bairros):
+    Update(table=tabela_bairros).clean()
+
+
+@pytest.mark.django_db
+def test_update_rejects_no_target():
+    with pytest.raises(ValidationError):
+        Update().clean()
+
+
+@pytest.mark.django_db
+def test_update_rejects_two_targets(tabela_bairros, raw_data_source):
+    with pytest.raises(ValidationError):
+        Update(table=tabela_bairros, raw_data_source=raw_data_source).clean()
+
+
+@pytest.mark.django_db
+def test_update_entity_must_be_datetime(tabela_bairros, entity_escola):
+    """entity_escola belongs to the "education" category."""
+    with pytest.raises(ValidationError) as exc:
+        Update(table=tabela_bairros, entity=entity_escola).clean()
+    assert "entity" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_update_accepts_a_datetime_entity(tabela_bairros, entity_anual):
+    entity_anual.category.slug = "datetime"
+    entity_anual.category.save()
+    Update(table=tabela_bairros, entity=entity_anual).clean()
+
+
+# ---------------------------------------------------------------------------
+# Poll
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_poll_accepts_exactly_one_target(raw_data_source):
+    Poll(raw_data_source=raw_data_source).clean()
+
+
+@pytest.mark.django_db
+def test_poll_rejects_no_target():
+    with pytest.raises(ValidationError):
+        Poll().clean()
+
+
+@pytest.mark.django_db
+def test_poll_rejects_two_targets(raw_data_source, pedido_informacao):
+    with pytest.raises(ValidationError):
+        Poll(raw_data_source=raw_data_source, information_request=pedido_informacao).clean()
+
+
+@pytest.mark.django_db
+def test_poll_entity_must_be_datetime(raw_data_source, entity_escola):
+    with pytest.raises(ValidationError) as exc:
+        Poll(raw_data_source=raw_data_source, entity=entity_escola).clean()
+    assert "entity" in exc.value.message_dict
+
+
+# ---------------------------------------------------------------------------
+# QualityCheck
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_quality_check_accepts_exactly_one_target(tabela_bairros):
+    QualityCheck(table=tabela_bairros).clean()
+
+
+@pytest.mark.django_db
+def test_quality_check_rejects_no_target():
+    with pytest.raises(ValidationError):
+        QualityCheck().clean()
+
+
+@pytest.mark.django_db
+def test_quality_check_rejects_two_targets(tabela_bairros, dataset_dados_mestres):
+    with pytest.raises(ValidationError):
+        QualityCheck(table=tabela_bairros, dataset=dataset_dados_mestres).clean()
+
+
+@pytest.mark.django_db
+def test_quality_check_ignores_pipeline_when_counting(tabela_bairros, pipeline):
+    """pipeline is not one of the mutually exclusive targets."""
+    QualityCheck(table=tabela_bairros, pipeline=pipeline).clean()
+
+
+# ---------------------------------------------------------------------------
+# DateTimeRange
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_since_and_until_assemble_full_datetimes():
+    dtr = DateTimeRange(
+        start_year=2021,
+        start_month=6,
+        start_day=15,
+        start_hour=10,
+        start_minute=30,
+        start_second=45,
+        end_year=2023,
+        end_month=1,
+        end_day=2,
+    )
+    assert dtr.since == datetime(2021, 6, 15, 10, 30, 45)
+    assert dtr.until == datetime(2023, 1, 2, 0, 0, 0)
+
+
+@pytest.mark.django_db
+def test_missing_parts_default_to_the_start_of_the_period():
+    dtr = DateTimeRange(start_year=2021, end_year=2023)
+    assert dtr.since == datetime(2021, 1, 1, 0, 0, 0)
+    assert dtr.until == datetime(2023, 1, 1, 0, 0, 0)
+
+
+@pytest.mark.django_db
+def test_since_is_none_without_a_start_year():
+    assert DateTimeRange(start_month=6).since is None
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"start_year": 2021, "start_month": 6, "start_day": 15}, "2021-06-15"),
+        ({"start_year": 2021, "start_month": 6}, "2021-06"),
+        ({"start_year": 2021}, "2021"),
+        ({}, ""),
+    ],
+)
+def test_since_str_precision_follows_the_fields_set(kwargs, expected):
+    assert DateTimeRange(**kwargs).since_str == expected
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"end_year": 2023, "end_month": 6, "end_day": 15}, "2023-06-15"),
+        ({"end_year": 2023, "end_month": 6}, "2023-06"),
+        ({"end_year": 2023}, "2023"),
+        ({}, ""),
+    ],
+)
+def test_until_str_precision_follows_the_fields_set(kwargs, expected):
+    assert DateTimeRange(**kwargs).until_str == expected
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("interval,expected", [(1, "1"), (12, "12"), (None, "0"), (0, "0")])
+def test_interval_str(interval, expected):
+    assert DateTimeRange(interval=interval).interval_str == expected
+
+
+@pytest.mark.django_db
+def test_clean_rejects_a_start_after_the_end():
+    dtr = DateTimeRange(start_year=2024, end_year=2020, interval=1)
+    with pytest.raises(ValidationError) as exc:
+        dtr.clean()
+    assert "date_range" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_clean_requires_an_interval_for_a_bounded_range():
+    dtr = DateTimeRange(start_year=2020, end_year=2024)
+    with pytest.raises(ValidationError) as exc:
+        dtr.clean()
+    assert "interval" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_clean_accepts_an_open_ended_range_without_an_interval():
+    DateTimeRange(start_year=2020).clean()
+
+
+@pytest.mark.django_db
+def test_clean_accepts_a_valid_bounded_range():
+    DateTimeRange(start_year=2020, end_year=2024, interval=1).clean()
+
+
+@pytest.mark.django_db
+def test_overlapping_ranges_are_similar():
+    first = DateTimeRange(start_year=2020, end_year=2023, interval=1)
+    second = DateTimeRange(start_year=2022, end_year=2025, interval=1)
+    assert first.get_similarity_of_datetime(second) == 1
+
+
+@pytest.mark.django_db
+def test_similarity_needs_a_start_on_the_left_and_an_end_on_the_right():
+    bounded = DateTimeRange(start_year=2020, end_year=2023, interval=1)
+    assert DateTimeRange().get_similarity_of_datetime(bounded) == 0
+    assert bounded.get_similarity_of_datetime(DateTimeRange(start_year=2020)) == 0

--- a/backend/apps/api/v1/tests/test_models.py
+++ b/backend/apps/api/v1/tests/test_models.py
@@ -2,7 +2,6 @@
 """
 Pytest Django models tests.
 """
-import json
 
 import pytest
 from django.core.exceptions import ValidationError
@@ -130,13 +129,14 @@ def test_table_create(tabela_bairros):
 def test_table_with_empty_coverage(tabela_bairros, coverage_tabela_open, datetime_range_empty):
     """
     Test for Table with Coverage containing no DateTimeRange.
-    Coverage must be empty string.
+    Temporal coverage must be unset.
     """
     tabela_bairros.save()
     coverage_tabela_open.save()
     datetime_range_empty.coverage = coverage_tabela_open
     datetime_range_empty.save()
-    assert tabela_bairros.dataset.coverage == ""
+    assert tabela_bairros.full_temporal_coverage is None
+    assert tabela_bairros.temporal_coverage == {"start": None, "end": None}
 
 
 @pytest.mark.django_db
@@ -253,13 +253,14 @@ def test_table_with_multiple_coverages(
     tabela_bairros.coverages.add(coverage_tabela_open, coverage_tabela_closed)
     tabela_bairros.save()
 
-    table_expected_coverage = [
-        {"year": "2021", "month": "06", "day": None, "type": "open"},
-        {"year": "2023", "month": "06", "day": None, "type": "open"},
-        {"year": "2026", "month": "06", "day": None, "type": "closed"},
+    # The free range ends where the paid range begins, so the middle step is the
+    # start of the closed range (2023-07), not the end of the open one.
+    assert tabela_bairros.full_temporal_coverage == [
+        {"date": "2021-06", "type": "open"},
+        {"date": "2023-07", "type": "open"},
+        {"date": "2026-06", "type": "closed"},
     ]
-
-    assert tabela_bairros.full_coverage == json.dumps(table_expected_coverage)
+    assert tabela_bairros.temporal_coverage == {"start": "2021-06", "end": "2026-06"}
 
 
 @pytest.mark.django_db
@@ -276,12 +277,12 @@ def test_table_with_open_coverages(
     tabela_bairros.coverages.add(coverage_tabela_open)
     tabela_bairros.save()
 
-    table_expected_coverage = [
-        {"year": "2021", "month": "06", "day": None, "type": "open"},
-        {"year": "2023", "month": "06", "day": None, "type": "open"},
+    assert tabela_bairros.full_temporal_coverage == [
+        {"date": "2021-06", "type": "open"},
+        {"date": "2023-06", "type": "open"},
     ]
-
-    assert tabela_bairros.full_coverage == json.dumps(table_expected_coverage)
+    assert tabela_bairros.contains_temporalcoverage_free is True
+    assert tabela_bairros.contains_temporalcoverage_paid is False
 
 
 @pytest.mark.django_db
@@ -298,9 +299,9 @@ def test_table_with_closed_coverages(
     tabela_bairros.coverages.add(coverage_tabela_closed)
     tabela_bairros.save()
 
-    table_expected_coverage = [
-        {"year": "2023", "month": "07", "day": None, "type": "closed"},
-        {"year": "2026", "month": "06", "day": None, "type": "closed"},
+    assert tabela_bairros.full_temporal_coverage == [
+        {"date": "2023-07", "type": "closed"},
+        {"date": "2026-06", "type": "closed"},
     ]
-
-    assert tabela_bairros.full_coverage == json.dumps(table_expected_coverage)
+    assert tabela_bairros.contains_temporalcoverage_free is False
+    assert tabela_bairros.contains_temporalcoverage_paid is True

--- a/backend/apps/api/v1/tests/test_spatial_coverage.py
+++ b/backend/apps/api/v1/tests/test_spatial_coverage.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Tests for spatial coverage aggregation.
+
+get_spatial_coverage collapses the areas of a resource's coverages to the highest
+level in each branch of the area hierarchy. The rules are stated in its docstring
+but were not exercised anywhere; these tests turn that docstring into a contract.
+"""
+
+import pytest
+
+from backend.apps.api.v1.models import Area, Coverage, get_spatial_coverage
+
+
+def cover(table, *slugs):
+    """Attach one coverage per area slug to a table."""
+    for slug in slugs:
+        area, _ = Area.objects.get_or_create(slug=slug)
+        Coverage.objects.create(table=table, area=area, is_closed=False)
+
+
+@pytest.mark.django_db
+def test_no_areas_returns_empty_list(tabela_bairros):
+    assert get_spatial_coverage([tabela_bairros]) == []
+
+
+@pytest.mark.django_db
+def test_coverage_without_area_is_ignored(tabela_bairros):
+    Coverage.objects.create(table=tabela_bairros, is_closed=False)
+    assert get_spatial_coverage([tabela_bairros]) == []
+
+
+@pytest.mark.django_db
+def test_duplicate_areas_are_deduplicated(tabela_bairros):
+    cover(tabela_bairros, "br_mg_3100104", "br_mg_3100104")
+    assert get_spatial_coverage([tabela_bairros]) == ["br_mg_3100104"]
+
+
+@pytest.mark.django_db
+def test_sibling_areas_are_both_kept(tabela_bairros):
+    cover(tabela_bairros, "br_mg_3100104", "br_sp_3500105")
+    assert get_spatial_coverage([tabela_bairros]) == ["br_mg_3100104", "br_sp_3500105"]
+
+
+@pytest.mark.django_db
+def test_child_is_dropped_when_its_parent_is_present(tabela_bairros):
+    """br_mg has no parent in the set and survives; us_ny is covered by us."""
+    cover(tabela_bairros, "br_mg", "us_ny", "us")
+    assert get_spatial_coverage([tabela_bairros]) == ["br_mg", "us"]
+
+
+@pytest.mark.django_db
+def test_world_absorbs_everything(tabela_bairros):
+    cover(tabela_bairros, "br_mg", "world", "us")
+    assert get_spatial_coverage([tabela_bairros]) == ["world"]
+
+
+@pytest.mark.django_db
+def test_grandparent_absorbs_grandchild(tabela_bairros):
+    cover(tabela_bairros, "br", "br_mg_3100104")
+    assert get_spatial_coverage([tabela_bairros]) == ["br"]
+
+
+@pytest.mark.django_db
+def test_result_is_sorted(tabela_bairros):
+    cover(tabela_bairros, "us_ny", "br_sp", "ar_ba")
+    assert get_spatial_coverage([tabela_bairros]) == ["ar_ba", "br_sp", "us_ny"]
+
+
+@pytest.mark.django_db
+def test_areas_are_unioned_across_resources(tabela_bairros, tabela_pro):
+    cover(tabela_bairros, "br_mg")
+    cover(tabela_pro, "br_sp")
+    assert get_spatial_coverage([tabela_bairros, tabela_pro]) == ["br_mg", "br_sp"]
+
+
+@pytest.mark.django_db
+def test_parent_in_a_second_resource_still_absorbs_the_child(tabela_bairros, tabela_pro):
+    """The hierarchy is collapsed over the union, not per resource."""
+    cover(tabela_bairros, "br_mg_3100104")
+    cover(tabela_pro, "br_mg")
+    assert get_spatial_coverage([tabela_bairros, tabela_pro]) == ["br_mg"]
+
+
+@pytest.mark.django_db
+def test_table_property_matches_the_helper(tabela_bairros):
+    cover(tabela_bairros, "br_mg", "br_mg_3100104")
+    assert tabela_bairros.spatial_coverage == ["br_mg"]
+
+
+@pytest.mark.django_db
+def test_column_falls_back_to_its_table(tabela_bairros, coluna_nome_bairros):
+    """A column with no area of its own reports the table's coverage."""
+    cover(tabela_bairros, "br_sp")
+    assert coluna_nome_bairros.spatial_coverage == ["br_sp"]
+
+
+@pytest.mark.django_db
+def test_column_area_overrides_the_table(tabela_bairros, coluna_nome_bairros):
+    cover(tabela_bairros, "br_sp")
+    area, _ = Area.objects.get_or_create(slug="br_mg")
+    Coverage.objects.create(column=coluna_nome_bairros, area=area, is_closed=False)
+    assert coluna_nome_bairros.spatial_coverage == ["br_mg"]

--- a/backend/apps/api/v1/tests/test_table_relations.py
+++ b/backend/apps/api/v1/tests/test_table_relations.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+"""Tests for Table and Column relational logic.
+
+Covers the overlap check in Table.clean, the similarity scores that drive the
+"related tables" feature, the directory-key constraint on Column, and the
+author/cleaner payloads the frontend renders.
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from backend.apps.api.v1.models import (
+    Area,
+    Coverage,
+    DateTimeRange,
+    Table,
+    TableNeighbor,
+)
+
+
+def covered(table, area, *, start, end, is_closed=False):
+    coverage = Coverage.objects.create(table=table, area=area, is_closed=is_closed)
+    DateTimeRange.objects.create(
+        coverage=coverage, start_year=start, end_year=end, start_month=1, end_month=1, interval=1
+    )
+    return coverage
+
+
+# ---------------------------------------------------------------------------
+# Table.clean: coverages must not overlap within an area
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_disjoint_coverages_in_one_area_are_fine(tabela_bairros, area_br):
+    covered(tabela_bairros, area_br, start=2018, end=2020)
+    covered(tabela_bairros, area_br, start=2021, end=2023)
+    tabela_bairros.clean()
+
+
+@pytest.mark.django_db
+def test_overlapping_coverages_in_one_area_are_rejected(tabela_bairros, area_br):
+    covered(tabela_bairros, area_br, start=2018, end=2022)
+    covered(tabela_bairros, area_br, start=2021, end=2023)
+    with pytest.raises(ValidationError) as exc:
+        tabela_bairros.clean()
+    assert "coverages_areas" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_overlaps_in_different_areas_are_fine(tabela_bairros, area_br):
+    """The check is per area, so two regions may cover the same years."""
+    outra = Area.objects.create(slug="ar", name="Argentina")
+    covered(tabela_bairros, area_br, start=2018, end=2022)
+    covered(tabela_bairros, outra, start=2018, end=2022)
+    tabela_bairros.clean()
+
+
+@pytest.mark.django_db
+def test_a_table_with_no_coverages_cleans(tabela_bairros):
+    tabela_bairros.clean()
+
+
+@pytest.mark.django_db
+def test_a_coverage_without_an_area_is_skipped(tabela_bairros):
+    Coverage.objects.create(table=tabela_bairros, is_closed=False)
+    tabela_bairros.clean()
+
+
+# ---------------------------------------------------------------------------
+# Similarity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_area_similarity_is_one_for_matching_areas(tabela_bairros, tabela_pro, area_br):
+    Coverage.objects.create(table=tabela_bairros, area=area_br, is_closed=False)
+    Coverage.objects.create(table=tabela_pro, area=area_br, is_closed=False)
+    assert tabela_bairros.get_similarity_of_area(tabela_pro) == 1
+
+
+@pytest.mark.django_db
+def test_area_similarity_is_zero_for_unrelated_areas(tabela_bairros, tabela_pro):
+    brasil = Area.objects.create(slug="br", name="Brasil")
+    argentina = Area.objects.create(slug="ar", name="Argentina")
+    Coverage.objects.create(table=tabela_bairros, area=brasil, is_closed=False)
+    Coverage.objects.create(table=tabela_pro, area=argentina, is_closed=False)
+    assert tabela_bairros.get_similarity_of_area(tabela_pro) == 0
+
+
+@pytest.mark.django_db
+def test_an_area_with_a_blank_name_matches_every_other_area(tabela_bairros, tabela_pro):
+    """Recorded, not endorsed: the comparison is a prefix test on Area.name.
+
+    Every string starts with "", so an Area saved without a name scores as
+    similar to all of them and inflates the related-tables ranking. Area.name is
+    declared blank=False, so full_clean() would reject one — but the similarity
+    code is reached from rows created without validation.
+    """
+    unnamed = Area.objects.create(slug="sem_nome", name="")
+    argentina = Area.objects.create(slug="ar", name="Argentina")
+    Coverage.objects.create(table=tabela_bairros, area=unnamed, is_closed=False)
+    Coverage.objects.create(table=tabela_pro, area=argentina, is_closed=False)
+    assert tabela_bairros.get_similarity_of_area(tabela_pro) == 1
+
+
+@pytest.mark.django_db
+def test_similarity_without_coverages_is_zero_rather_than_a_division_error(
+    tabela_bairros, tabela_pro
+):
+    assert tabela_bairros.get_similarity_of_area(tabela_pro) == 0
+    assert tabela_bairros.get_similarity_of_datetime(tabela_pro) == 0
+
+
+@pytest.mark.django_db
+def test_datetime_similarity_is_one_for_overlapping_ranges(tabela_bairros, tabela_pro, area_br):
+    covered(tabela_bairros, area_br, start=2018, end=2022)
+    covered(tabela_pro, area_br, start=2021, end=2024)
+    assert tabela_bairros.get_similarity_of_datetime(tabela_pro) == 1
+
+
+@pytest.mark.django_db
+def test_directory_similarity_counts_shared_directory_keys(
+    tabela_bairros,
+    tabela_pro,
+    coluna_state_id_bairros,
+    coluna_state_id_diretorio,
+    bigquery_type_string,
+):
+    from backend.apps.api.v1.models import Column
+
+    Column.objects.create(
+        table=tabela_pro,
+        name="ID do estado",
+        bigquery_type=bigquery_type_string,
+        directory_primary_key=coluna_state_id_diretorio,
+        order=1,
+    )
+    ratio, shared = tabela_bairros.get_similarity_of_directory(tabela_pro)
+    assert ratio == 1
+    assert shared == {coluna_state_id_diretorio}
+
+
+@pytest.mark.django_db
+def test_directory_similarity_is_zero_without_a_shared_key(
+    tabela_bairros, tabela_pro, coluna_state_id_bairros
+):
+    ratio, shared = tabela_bairros.get_similarity_of_directory(tabela_pro)
+    assert ratio == 0
+    assert shared == set()
+
+
+# ---------------------------------------------------------------------------
+# TableNeighbor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_a_table_cannot_neighbour_itself(tabela_bairros):
+    neighbor = TableNeighbor(table_a=tabela_bairros, table_b=tabela_bairros)
+    with pytest.raises(ValidationError) as exc:
+        neighbor.clean()
+    assert set(exc.value.message_dict) == {"table_a", "table_b"}
+
+
+@pytest.mark.django_db
+def test_two_different_tables_may_be_neighbours(tabela_bairros, tabela_pro):
+    TableNeighbor(table_a=tabela_bairros, table_b=tabela_pro).clean()
+
+
+@pytest.mark.django_db
+def test_the_neighbour_score_sums_the_rounded_components(tabela_bairros, tabela_pro):
+    neighbor = TableNeighbor.objects.create(
+        table_a=tabela_bairros,
+        table_b=tabela_pro,
+        similarity_of_directory=0.666,
+        similarity_of_popularity=0.334,
+    )
+    assert neighbor.score == pytest.approx(1.0)
+
+
+@pytest.mark.django_db
+def test_the_neighbour_payload_describes_the_other_table(tabela_bairros, tabela_pro):
+    neighbor = TableNeighbor.objects.create(
+        table_a=tabela_bairros,
+        table_b=tabela_pro,
+        similarity_of_directory=0.5,
+        similarity_of_popularity=0.25,
+    )
+    payload = neighbor.as_dict
+    assert payload["table_id"] == str(tabela_pro.pk)
+    assert payload["table_name"] == tabela_pro.name
+    assert payload["dataset_id"] == str(tabela_pro.dataset.pk)
+
+
+# ---------------------------------------------------------------------------
+# Column.clean
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_a_directory_key_must_live_in_a_directory_table(
+    tabela_bairros, coluna_nome_bairros, coluna_populacao_bairros
+):
+    """coluna_populacao_bairros belongs to a table with is_directory=False."""
+    coluna_nome_bairros.directory_primary_key = coluna_populacao_bairros
+    with pytest.raises(ValidationError) as exc:
+        coluna_nome_bairros.clean()
+    assert "directory_primary_key" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_a_directory_key_in_a_directory_table_is_accepted(
+    coluna_state_id_bairros, coluna_state_id_diretorio
+):
+    coluna_state_id_bairros.clean()
+
+
+@pytest.mark.django_db
+def test_an_observation_level_must_belong_to_the_same_table(
+    coluna_nome_bairros, tabela_pro, entity_anual
+):
+    from backend.apps.api.v1.models import ObservationLevel
+
+    observation = ObservationLevel.objects.create(entity=entity_anual, table=tabela_pro)
+    coluna_nome_bairros.observation_level = observation
+    with pytest.raises(ValidationError) as exc:
+        coluna_nome_bairros.clean()
+    assert "observation_level" in exc.value.message_dict
+
+
+@pytest.mark.django_db
+def test_a_column_without_extras_cleans(coluna_populacao_bairros):
+    coluna_populacao_bairros.clean()
+
+
+# ---------------------------------------------------------------------------
+# Author payloads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_author_payloads_are_empty_without_authors(tabela_bairros):
+    assert tabela_bairros.published_by_info == []
+    assert tabela_bairros.data_cleaned_by_info == []
+
+
+@pytest.mark.django_db
+def test_the_author_payload_carries_the_public_profile(tabela_bairros, usuario_inicio):
+    usuario_inicio.github = "https://github.com/usuario"
+    usuario_inicio.website = "https://usuario.dev"
+    usuario_inicio.save()
+    tabela_bairros.published_by.add(usuario_inicio)
+
+    payload = tabela_bairros.published_by_info
+    assert payload == [
+        {
+            "firstName": "Usuario",
+            "lastName": "Inicio",
+            "email": "usuario@usuario.com",
+            "github": "https://github.com/usuario",
+            "twitter": usuario_inicio.twitter,
+            "website": "https://usuario.dev",
+        }
+    ]
+
+
+@pytest.mark.django_db
+def test_the_cleaner_payload_uses_the_same_shape(tabela_bairros, usuario_inicio):
+    tabela_bairros.data_cleaned_by.add(usuario_inicio)
+    assert tabela_bairros.data_cleaned_by_info[0]["email"] == "usuario@usuario.com"
+
+
+# ---------------------------------------------------------------------------
+# Partitions and coverage units
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_partitions_lists_only_partition_columns(
+    tabela_bairros, coluna_nome_bairros, coluna_populacao_bairros
+):
+    assert tabela_bairros.partitions == ""
+    coluna_populacao_bairros.is_partition = True
+    coluna_populacao_bairros.save()
+    assert Table.objects.get(pk=tabela_bairros.pk).partitions == "População"
+
+
+@pytest.mark.django_db
+def test_coverage_datetime_units_is_none_without_units(tabela_bairros, coverage_tabela_open):
+    assert tabela_bairros.coverage_datetime_units is None

--- a/backend/apps/api/v1/tests/test_views.py
+++ b/backend/apps/api/v1/tests/test_views.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+"""Tests for the api/v1 REST endpoints.
+
+table_stats feeds the public "how much data is there" counters, columns_view
+backs the table page, and DatasetRedirectView keeps old dataset links alive.
+None of the three had coverage.
+"""
+
+import json
+
+import pytest
+from django.test.client import Client
+
+from backend.apps.api.v1.models import CloudTable, Status, Table
+
+MB = 1024 * 1024
+HOST = "localhost:8080"
+
+
+@pytest.fixture(name="status_excluded")
+def fixture_status_excluded():
+    return Status.objects.create(name="Excluído", slug="excluded")
+
+
+# ---------------------------------------------------------------------------
+# table_stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_table_stats_on_an_empty_database(client: Client):
+    response = client.get("/tables/stats/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "datasets_with_treated_tables": 0,
+        "total_treated_tables": 0,
+        "updated_last_30_days": 0,
+        "total_size_bytes": 0,
+        "total_rows": 0,
+    }
+
+
+@pytest.mark.django_db
+def test_table_stats_counts_and_sums_visible_tables(client: Client, tabela_bairros):
+    data = client.get("/tables/stats/").json()
+    assert data["total_treated_tables"] == 1
+    assert data["datasets_with_treated_tables"] == 1
+    assert data["total_size_bytes"] == 1000
+    assert data["total_rows"] == 100
+
+
+@pytest.mark.django_db
+def test_table_stats_applies_the_same_exclusions_as_the_dataset_aggregates(
+    client: Client, dataset_dados_mestres, status_excluded
+):
+    Table.objects.create(dataset=dataset_dados_mestres, slug="visivel", name="v", order=0)
+    Table.objects.create(
+        dataset=dataset_dados_mestres, slug="oculta", name="o", status=status_excluded, order=1
+    )
+    Table.objects.create(dataset=dataset_dados_mestres, slug="dicionario", name="d", order=2)
+    assert client.get("/tables/stats/").json()["total_treated_tables"] == 1
+
+
+@pytest.mark.django_db
+def test_table_stats_sums_across_tables(client: Client, dataset_dados_mestres):
+    Table.objects.create(
+        dataset=dataset_dados_mestres,
+        slug="a",
+        name="a",
+        uncompressed_file_size=10 * MB,
+        number_rows=5,
+        order=0,
+    )
+    Table.objects.create(
+        dataset=dataset_dados_mestres,
+        slug="b",
+        name="b",
+        uncompressed_file_size=20 * MB,
+        number_rows=7,
+        order=1,
+    )
+    data = client.get("/tables/stats/").json()
+    assert data["total_size_bytes"] == 30 * MB
+    assert data["total_rows"] == 12
+
+
+# ---------------------------------------------------------------------------
+# columns_view
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_a_single_column_is_serialised(client: Client, coluna_nome_bairros):
+    response = client.get(f"/columns/{coluna_nome_bairros.id}/")
+    assert response.status_code == 200
+    payload = json.loads(response.content)
+    assert payload[0]["fields"]["name"] == "Nome do bairro"
+
+
+@pytest.mark.django_db
+def test_an_unknown_column_is_a_404(client: Client):
+    response = client.get("/columns/00000000-0000-0000-0000-000000000000/")
+    assert response.status_code == 404
+    assert response.json() == {"error": "Column not found"}
+
+
+@pytest.mark.django_db
+def test_a_tables_columns_come_back_in_order(
+    client: Client, tabela_bairros, coluna_nome_bairros, coluna_populacao_bairros
+):
+    response = client.get(f"/tables/{tabela_bairros.id}/columns/")
+    assert response.status_code == 200
+    payload = response.json()
+    assert [c["name"] for c in payload] == ["Nome do bairro", "População"]
+    assert [c["order"] for c in payload] == [2, 3]
+
+
+@pytest.mark.django_db
+def test_a_table_without_columns_is_a_404(client: Client, tabela_bairros):
+    response = client.get(f"/tables/{tabela_bairros.id}/columns/")
+    assert response.status_code == 404
+    assert response.json() == {"error": "Table not found or has no columns"}
+
+
+@pytest.mark.django_db
+def test_a_column_reports_its_own_temporal_coverage(
+    client: Client,
+    tabela_bairros,
+    coluna_nome_bairros,
+    coverage_coluna_open,
+    datetime_range_2,
+):
+    datetime_range_2.coverage = coverage_coluna_open
+    datetime_range_2.save()
+    payload = client.get(f"/tables/{tabela_bairros.id}/columns/").json()
+    assert payload[0]["temporal_coverage"] == {"start": "2022-06", "end": "2024-06"}
+
+
+@pytest.mark.django_db
+def test_a_column_without_coverage_inherits_the_tables(
+    client: Client,
+    tabela_bairros,
+    coluna_nome_bairros,
+    coverage_tabela_open,
+    datetime_range_1,
+):
+    datetime_range_1.coverage = coverage_tabela_open
+    datetime_range_1.save()
+    payload = client.get(f"/tables/{tabela_bairros.id}/columns/").json()
+    assert payload[0]["temporal_coverage"] == {"start": "2021-06", "end": "2023-06"}
+
+
+@pytest.mark.django_db
+def test_a_directory_column_carries_its_target(
+    client: Client,
+    tabela_bairros,
+    coluna_state_id_bairros,
+    tabela_diretorios_brasil_uf,
+):
+    CloudTable.objects.create(
+        table=tabela_diretorios_brasil_uf,
+        gcp_project_id="basedosdados",
+        gcp_dataset_id="br_bd_diretorios_brasil",
+        gcp_table_id="uf",
+    )
+    payload = client.get(f"/tables/{tabela_bairros.id}/columns/").json()
+    dpk = payload[0]["directory_primary_key"]
+    assert dpk["name"] == "ID do estado no diretório"
+    assert dpk["table"]["cloud_table"]["gcp_table_id"] == "uf"
+
+
+@pytest.mark.django_db
+def test_a_directory_column_without_a_cloud_table_reports_none(
+    client: Client, tabela_bairros, coluna_state_id_bairros
+):
+    payload = client.get(f"/tables/{tabela_bairros.id}/columns/").json()
+    assert payload[0]["directory_primary_key"]["table"]["cloud_table"] is None
+
+
+@pytest.mark.django_db
+def test_the_unfiltered_listing_serialises_columns(client: Client, coluna_nome_bairros):
+    response = client.get("/columns/")
+    assert response.status_code == 200
+    assert len(json.loads(response.content)) >= 1
+
+
+# ---------------------------------------------------------------------------
+# DatasetRedirectView
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_a_dataset_slug_redirects_to_the_frontend(client: Client, dataset_dados_mestres):
+    response = client.get("/dataset/", {"dataset": "dados_mestres"}, HTTP_HOST=HOST)
+    assert response.status_code == 302
+    assert response.url == f"http://localhost:3000/dataset/{dataset_dados_mestres.id}"
+
+
+@pytest.mark.django_db
+def test_dashes_in_the_legacy_slug_are_translated_to_underscores(
+    client: Client, dataset_dados_mestres
+):
+    response = client.get("/dataset/", {"dataset": "dados-mestres"}, HTTP_HOST=HOST)
+    assert response.url == f"http://localhost:3000/dataset/{dataset_dados_mestres.id}"
+
+
+@pytest.mark.django_db
+def test_a_bigquery_dataset_id_resolves_through_its_cloud_table(
+    client: Client, tabela_bairros, dataset_dados_mestres
+):
+    CloudTable.objects.create(
+        table=tabela_bairros,
+        gcp_project_id="basedosdados",
+        gcp_dataset_id="mundo_transferwise",
+        gcp_table_id="taxa_cambio",
+    )
+    response = client.get("/dataset/", {"dataset": "mundo_transferwise"}, HTTP_HOST=HOST)
+    assert response.url == f"http://localhost:3000/dataset/{dataset_dados_mestres.id}"
+
+
+@pytest.mark.django_db
+def test_an_unknown_dataset_redirects_to_404(client: Client):
+    response = client.get("/dataset/", {"dataset": "nao_existe"}, HTTP_HOST=HOST)
+    assert response.url == "http://localhost:3000/404"
+
+
+@pytest.mark.django_db
+def test_no_dataset_parameter_redirects_to_404(client: Client):
+    response = client.get("/dataset/", HTTP_HOST=HOST)
+    assert response.url == "http://localhost:3000/404"
+
+
+@pytest.mark.django_db
+def test_an_unmapped_host_raises(client: Client):
+    """URL_MAPPING is indexed directly, so an unlisted host is a KeyError.
+
+    Recorded rather than endorsed: the view has no fallback, and any host
+    outside the four it knows about produces a 500 instead of a redirect.
+    """
+    with pytest.raises(KeyError):
+        client.get("/dataset/", {"dataset": "x"}, HTTP_HOST="unmapped.example.com")
+
+
+@pytest.mark.django_db
+def test_the_api_root_redirects_to_graphql(client: Client):
+    assert client.get("/api/").status_code == 302
+    assert client.get("/api/v1/").status_code == 302

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -2,6 +2,7 @@
 """
 Pytest conftest
 """
+
 import uuid
 
 import pytest
@@ -374,15 +375,16 @@ def fixture_dataset_dados_mestres(
     organizacao_bd,
     status_em_processamento,
 ):
-    """Test for Dataset."""
-    return Dataset.objects.create(
-        organization=organizacao_bd,
+    """Fixture for Dataset."""
+    dataset = Dataset.objects.create(
         slug="dados_mestres",
         name="Dados Mestres",
         description="Descrição dos dados mestres",
         status=status_em_processamento,
         version=1,
     )
+    dataset.organizations.add(organizacao_bd)
+    return dataset
 
 
 #############################################################################################
@@ -442,7 +444,6 @@ def fixture_tabela_pro(
         is_directory=False,
         data_cleaning_description="Descrição da limpeza de dados",
         data_cleaning_code_url="http://cleaning.com/pro_table",
-        raw_data_url="http://raw.com/pro_table",
         auxiliary_files_url="http://aux.com/pro_table",
         architecture_url="http://arch.com/pro_table",
         source_bucket_name="basedosdados-dev",
@@ -475,7 +476,6 @@ def fixture_tabela_diretorios_brasil_uf(
         is_directory=True,
         data_cleaning_description="Descrição da limpeza de dados",
         data_cleaning_code_url="http://cleaning.com/brasil_uf",
-        raw_data_url="http://raw.com/brasil_uf",
         auxiliary_files_url="http://aux.com/brasil_uf",
         architecture_url="http://arch.com/brasil_uf",
         source_bucket_name="basedosdados-dev",

--- a/backend/custom/tests/test_environment.py
+++ b/backend/custom/tests/test_environment.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""Tests for backend.custom.environment.
+
+These helpers decide whether the deployment is production. Several code paths
+branch on them — activation emails are only sent when is_prd() is true, and
+production_task/not_production_task gate whole functions — so a wrong answer here
+is silent rather than loud.
+"""
+
+from importlib import reload
+
+import pytest
+
+from backend.custom import environment
+
+
+def configure(monkeypatch, settings_module: str, backend_url: str):
+    """Reload the module with a given environment.
+
+    SETTINGS and BACKEND_URL are read once at import time, so the module has to be
+    reloaded for a change to take effect.
+    """
+    monkeypatch.setenv("DJANGO_SETTINGS_MODULE", settings_module)
+    monkeypatch.setenv("BASE_URL_BACKEND", backend_url)
+    reload(environment)
+    return environment
+
+
+@pytest.fixture(autouse=True)
+def restore_module():
+    """Leave the module as the rest of the suite found it."""
+    yield
+    reload(environment)
+
+
+LOCAL = ("backend.settings.local", "https://localhost:8080")
+DEV = ("backend.settings.remote", "https://development.backend.basedosdados.org")
+STG = ("backend.settings.remote", "https://staging.backend.basedosdados.org")
+PRD = ("backend.settings.remote", "https://backend.basedosdados.org")
+
+
+@pytest.mark.parametrize(
+    "config,remote,dev,stg,prd",
+    [
+        (LOCAL, False, False, False, False),
+        (DEV, True, True, False, False),
+        (STG, True, False, True, False),
+        (PRD, True, False, False, True),
+    ],
+    ids=["local", "development", "staging", "production"],
+)
+def test_environment_detection(monkeypatch, config, remote, dev, stg, prd):
+    env = configure(monkeypatch, *config)
+    assert env.is_remote() is remote
+    assert env.is_dev() is dev
+    assert env.is_stg() is stg
+    assert env.is_prd() is prd
+
+
+def test_remote_settings_with_local_url_is_not_remote(monkeypatch):
+    """Both halves of the check must hold: remote settings alone are not enough."""
+    env = configure(monkeypatch, "backend.settings.remote", "https://localhost:8080")
+    assert env.is_remote() is False
+    assert env.is_prd() is False
+
+
+def test_local_settings_with_production_url_is_not_remote(monkeypatch):
+    env = configure(monkeypatch, "backend.settings.local", "https://backend.basedosdados.org")
+    assert env.is_remote() is False
+    assert env.is_prd() is False
+
+
+@pytest.mark.parametrize(
+    "config,backend_url,frontend_url",
+    [
+        (LOCAL, "localhost:8080", "localhost:3000"),
+        (DEV, "development.backend.basedosdados.org", "development.basedosdados.org"),
+        (STG, "staging.backend.basedosdados.org", "staging.basedosdados.org"),
+        (PRD, "backend.basedosdados.org", "basedosdados.org"),
+    ],
+    ids=["local", "development", "staging", "production"],
+)
+def test_urls_by_environment(monkeypatch, config, backend_url, frontend_url):
+    env = configure(monkeypatch, *config)
+    assert env.get_backend_url() == backend_url
+    assert env.get_frontend_url() == frontend_url
+
+
+def test_production_task_runs_only_in_production(monkeypatch):
+    env = configure(monkeypatch, *PRD)
+    calls = []
+
+    @env.production_task
+    def task():
+        calls.append(1)
+        return "ran"
+
+    assert task() == "ran"
+    assert calls == [1]
+
+
+def test_production_task_is_skipped_outside_production(monkeypatch):
+    env = configure(monkeypatch, *STG)
+    calls = []
+
+    @env.production_task
+    def task():
+        calls.append(1)
+        return "ran"
+
+    assert task() is None
+    assert calls == []
+
+
+def test_not_production_task_is_skipped_in_production(monkeypatch):
+    env = configure(monkeypatch, *PRD)
+    calls = []
+
+    @env.not_production_task
+    def task():
+        calls.append(1)
+
+    assert task() is None
+    assert calls == []
+
+
+def test_not_production_task_runs_outside_production(monkeypatch):
+    env = configure(monkeypatch, *DEV)
+    calls = []
+
+    @env.not_production_task
+    def task():
+        calls.append(1)
+        return "ran"
+
+    assert task() == "ran"
+    assert calls == [1]
+
+
+def test_decorators_preserve_metadata(monkeypatch):
+    env = configure(monkeypatch, *PRD)
+
+    @env.production_task
+    def documented_task():
+        """A docstring worth keeping."""
+
+    assert documented_task.__name__ == "documented_task"
+    assert documented_task.__doc__ == "A docstring worth keeping."

--- a/backend/custom/tests/test_environment.py
+++ b/backend/custom/tests/test_environment.py
@@ -146,3 +146,52 @@ def test_decorators_preserve_metadata(monkeypatch):
 
     assert documented_task.__name__ == "documented_task"
     assert documented_task.__doc__ == "A docstring worth keeping."
+
+
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        (LOCAL, {"http://localhost:3000"}),
+        (
+            DEV,
+            {
+                "https://development.basedosdados.org",
+                "https://development.data-basis.org",
+                "https://development.basedelosdatos.org",
+            },
+        ),
+        (
+            STG,
+            {
+                "https://staging.basedosdados.org",
+                "https://staging.data-basis.org",
+                "https://staging.basedelosdatos.org",
+            },
+        ),
+        (
+            PRD,
+            {
+                "https://basedosdados.org",
+                "https://data-basis.org",
+                "https://basedelosdatos.org",
+            },
+        ),
+    ],
+    ids=["local", "development", "staging", "production"],
+)
+def test_allowed_frontend_origins_by_environment(monkeypatch, config, expected):
+    """The post-login redirect allowlist. A JWT rides in that redirect, so an
+    origin leaking onto this list is a token disclosure, not a cosmetic bug."""
+    env = configure(monkeypatch, *config)
+    assert env.get_allowed_frontend_origins() == expected
+
+
+def test_production_origins_are_not_allowed_locally(monkeypatch):
+    env = configure(monkeypatch, *LOCAL)
+    assert "https://basedosdados.org" not in env.get_allowed_frontend_origins()
+
+
+def test_every_allowed_origin_is_https_when_remote(monkeypatch):
+    for config in (DEV, STG, PRD):
+        env = configure(monkeypatch, *config)
+        assert all(o.startswith("https://") for o in env.get_allowed_frontend_origins())

--- a/backend/custom/tests/test_graphql_jwt.py
+++ b/backend/custom/tests/test_graphql_jwt.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+"""Tests for the GraphQL authorization decorators.
+
+owner_required and subscription_member are the authorization boundary for the
+GraphQL API: they decide whether a caller may read or write a given account or
+subscription. owner_required identifies the target by regex over the raw request
+body, which is unusual enough to be worth pinning down precisely.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from graphql import GraphQLResolveInfo
+from graphql_jwt import exceptions
+
+from backend.custom.graphql_jwt import (
+    anyone_required,
+    jwt_payload_with_uuid,
+    owner_required,
+    subscription_member,
+)
+
+
+def make_context(*, body=b"{}", is_staff=False, is_superuser=False, authenticated=True, uid=None):
+    return SimpleNamespace(
+        body=body,
+        _post={},
+        user=SimpleNamespace(
+            id=uid,
+            is_staff=is_staff,
+            is_superuser=is_superuser,
+            is_authenticated=authenticated,
+            is_anonymous=not authenticated,
+        ),
+    )
+
+
+def resolver(root, info, **kwargs):
+    return "resolved"
+
+
+def resolve_info(context):
+    """graphql_jwt's @context finds the info by isinstance, so it must be the real type."""
+    info = MagicMock(spec=GraphQLResolveInfo)
+    info.context = context
+    return info
+
+
+def call(decorated, context):
+    return decorated(None, resolve_info(context))
+
+
+# ---------------------------------------------------------------------------
+# JWT payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_the_jwt_payload_carries_the_account_uuid():
+    from backend.apps.account.models import Account
+
+    account = Account.objects.create_user(
+        email="john.doe@email.com",
+        password="12345678",
+        username="john.doe",
+        first_name="John",
+        last_name="Doe",
+    )
+    payload = jwt_payload_with_uuid(account)
+    assert payload["uuid"] == str(account.uuid)
+    assert "exp" in payload
+
+
+# ---------------------------------------------------------------------------
+# anyone_required
+# ---------------------------------------------------------------------------
+
+
+def test_anyone_required_is_a_passthrough():
+    decorated = anyone_required(resolver)
+    assert decorated(None, None) == "resolved"
+    assert decorated.__name__ == "resolver"
+
+
+# ---------------------------------------------------------------------------
+# owner_required
+# ---------------------------------------------------------------------------
+
+
+def test_staff_may_act_on_anyone():
+    decorated = owner_required()(resolver)
+    body = b"mutation { updateAccount(input: {id: 999}) { id } }"
+    assert call(decorated, make_context(is_staff=True, uid=1, body=body)) == "resolved"
+
+
+def test_a_superuser_may_act_on_anyone():
+    decorated = owner_required()(resolver)
+    body = b"mutation { updateAccount(input: {id: 999}) { id } }"
+    context = make_context(is_superuser=True, uid=1, body=body)
+    assert call(decorated, context) == "resolved"
+
+
+def test_a_user_may_act_on_their_own_record():
+    decorated = owner_required()(resolver)
+    body = b'mutation { updateAccount(input: {id: 42, firstName: "John"}) { id } }'
+    assert call(decorated, make_context(uid=42, body=body)) == "resolved"
+
+
+def test_a_user_may_not_act_on_someone_elses_record():
+    decorated = owner_required()(resolver)
+    body = b"mutation { updateAccount(input: {id: 99}) { id } }"
+    with pytest.raises(exceptions.PermissionDenied):
+        call(decorated, make_context(uid=42, body=body))
+
+
+def test_a_user_may_not_act_on_an_unidentified_record():
+    """With no id in the body there is nothing to match the caller against."""
+    decorated = owner_required()(resolver)
+    with pytest.raises(exceptions.PermissionDenied):
+        call(decorated, make_context(uid=42, body=b"{}"))
+
+
+def test_an_anonymous_caller_is_denied_by_default():
+    decorated = owner_required()(resolver)
+    with pytest.raises(exceptions.PermissionDenied):
+        call(decorated, make_context(authenticated=False))
+
+
+def test_an_anonymous_caller_may_create_when_allowed():
+    """Registration: no id in the body means no existing record is targeted."""
+    decorated = owner_required(allow_anonymous=True)(resolver)
+    assert call(decorated, make_context(authenticated=False)) == "resolved"
+
+
+def test_an_anonymous_caller_may_not_target_an_existing_record():
+    decorated = owner_required(allow_anonymous=True)(resolver)
+    body = b"mutation { updateAccount(input: {id: 42}) { id } }"
+    with pytest.raises(exceptions.PermissionDenied):
+        call(decorated, make_context(authenticated=False, body=body))
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"mutation { x(id: 42) }",
+        b'mutation { x(id: "42") }',
+        b"mutation { x(ID: 42) }",  # the body is lowercased before matching
+        b"{ account(id: 42) { email } }",
+    ],
+)
+def test_the_id_is_found_in_graphql_argument_syntax(body):
+    decorated = owner_required()(resolver)
+    assert call(decorated, make_context(uid=42, body=body)) == "resolved"
+
+
+@pytest.mark.parametrize("body", [b'{"id": 42}', b'{"id": "42"}', b"{'id':42}"])
+def test_a_json_style_key_is_not_recognised_as_an_id(body):
+    """The pattern needs `id:` followed by whitespace, so a quoted JSON key misses.
+
+    Recorded because it is load-bearing: an unrecognised id means owner_required
+    treats the request as targeting no record, which denies an authenticated
+    caller and, with allow_anonymous, permits an anonymous one. GraphQL request
+    bodies carry the query in GraphQL syntax, so the pattern matches in practice.
+    """
+    decorated = owner_required()(resolver)
+    with pytest.raises(exceptions.PermissionDenied):
+        call(decorated, make_context(uid=42, body=body))
+
+
+def test_an_undecodable_body_falls_back_to_post_data():
+    decorated = owner_required()(resolver)
+    context = make_context(uid=42)
+    context.body = MagicMock()
+    context.body.decode.side_effect = UnicodeDecodeError("utf-8", b"", 0, 1, "boom")
+    context._post = {"query": "mutation { x(id: 42) }"}
+    assert call(decorated, context) == "resolved"
+
+
+def test_a_custom_exception_can_be_supplied():
+    class Denied(Exception):
+        pass
+
+    decorated = owner_required(exc=Denied)(resolver)
+    with pytest.raises(Denied):
+        call(decorated, make_context(authenticated=False))
+
+
+# ---------------------------------------------------------------------------
+# subscription_member
+# ---------------------------------------------------------------------------
+
+
+class FakeQuerySet:
+    """Records the filter it was asked for, so the branch taken is observable."""
+
+    def __init__(self):
+        self.filtered_with = None
+
+    def filter(self, *args, **kwargs):
+        self.filtered_with = (args, kwargs)
+        return self
+
+
+def subscription_resolver(root, info, **kwargs):
+    return info.context.queryset
+
+
+def call_subscription(decorated, context):
+    context.queryset = FakeQuerySet()
+    result = decorated(None, resolve_info(context))
+    return context.queryset, result
+
+
+def test_an_anonymous_caller_cannot_read_subscriptions():
+    decorated = subscription_member()(subscription_resolver)
+    with pytest.raises(exceptions.PermissionDenied):
+        call_subscription(decorated, make_context(authenticated=False))
+
+
+def test_staff_see_subscriptions_unfiltered():
+    decorated = subscription_member()(subscription_resolver)
+    queryset, _ = call_subscription(decorated, make_context(is_staff=True))
+    assert queryset.filtered_with is None
+
+
+def test_a_superuser_sees_subscriptions_unfiltered():
+    decorated = subscription_member()(subscription_resolver)
+    queryset, _ = call_subscription(decorated, make_context(is_superuser=True))
+    assert queryset.filtered_with is None
+
+
+def test_a_member_sees_subscriptions_they_own_or_belong_to():
+    decorated = subscription_member()(subscription_resolver)
+    queryset, _ = call_subscription(decorated, make_context(uid=42))
+    assert queryset.filtered_with is not None
+    args, kwargs = queryset.filtered_with
+    assert args and not kwargs  # a Q object, covering both owner and member
+
+
+def test_only_admin_narrows_to_the_owner():
+    decorated = subscription_member(only_admin=True)(subscription_resolver)
+    queryset, _ = call_subscription(decorated, make_context(uid=42))
+    _, kwargs = queryset.filtered_with
+    assert set(kwargs) == {"admin"}

--- a/backend/custom/tests/test_utils.py
+++ b/backend/custom/tests/test_utils.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""Tests for backend.custom.utils.
+
+check_snake_case and check_kebab_case gate CloudTable validation: they decide
+whether a BigQuery project, dataset, and table identifier is well formed.
+"""
+
+import pytest
+
+from backend.custom.utils import check_kebab_case, check_snake_case
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["tabela_bairros", "bairros", "br_ms_mte_caged", "tabela1", "1tabela", "a", "a_1"],
+)
+def test_snake_case_accepts(name):
+    assert check_snake_case(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Tabela",  # uppercase
+        "TABELA",
+        "tabela-bairros",  # kebab separator
+        "tabela bairros",  # space
+        "tabela.bairros",  # dot
+        "_tabela",  # leading underscore
+        "tabela__bairros!",  # punctuation
+        "tabelá",  # accented
+    ],
+)
+def test_snake_case_rejects(name):
+    assert check_snake_case(name) is False
+
+
+@pytest.mark.parametrize("name", ["basedosdados-dev", "basedosdados", "bd1", "a-b-c"])
+def test_kebab_case_accepts(name):
+    assert check_kebab_case(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Basedosdados",
+        "base_dos_dados",  # snake separator
+        "-basedosdados",  # leading dash
+        "base dos dados",
+        "base.dos.dados",
+    ],
+)
+def test_kebab_case_rejects(name):
+    assert check_kebab_case(name) is False
+
+
+@pytest.mark.parametrize("check", [check_snake_case, check_kebab_case])
+def test_empty_string_raises(check):
+    """Both helpers index name[0] without a length guard.
+
+    Documented here so the behaviour is a decision rather than a surprise: callers
+    must not pass an empty string. CloudTable.clean() guards each call with a
+    truthiness check for this reason.
+    """
+    with pytest.raises(IndexError):
+        check("")

--- a/backend/settings/test.py
+++ b/backend/settings/test.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""Settings used by the test suite.
+
+Inherits the local settings and neutralises the external services the suite has
+no business talking to. Without this every ``save()`` in a test tries to reach
+Elasticsearch, fails, and logs a traceback.
+"""
+
+from os import getenv
+
+from .local import *  # noqa: F401,F403
+
+# Search: no Elasticsearch in CI. Use the in-memory backend and drop the signal
+# processor so model saves don't attempt to index.
+HAYSTACK_CONNECTIONS = {
+    "default": {
+        "ENGINE": "haystack.backends.simple_backend.SimpleEngine",
+    }
+}
+HAYSTACK_SIGNAL_PROCESSOR = "haystack.signals.BaseSignalProcessor"
+
+# Email: keep messages in memory instead of opening SMTP connections.
+EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+# JWT: base settings read this from the environment and fall back to None, which
+# makes django-graphql-jwt sign with alg="none" and reject every login.
+GRAPHQL_JWT = {  # noqa: F405
+    **GRAPHQL_JWT,  # noqa: F405
+    "JWT_ALGORITHM": getenv("DJANGO_JWT_ALGORITHM", "HS256"),
+}
+
+# Note: do not swap in a faster password hasher here. Account.save() validates the
+# stored hash with is_valid_encoded_password(), which assumes a four-part
+# "algorithm$iterations$salt$hash" encoding. A three-part hasher such as MD5 fails
+# that check and the model silently re-hashes an already-hashed password.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=backend.settings
+DJANGO_SETTINGS_MODULE=backend.settings.test
 python_files = tests.py test_*.py *_tests.py
 filterwarnings =
     ignore::DeprecationWarning


### PR DESCRIPTION
### Purpose

The CI test job has not executed a single test since February 2024, and has
reported success the whole time.

`poetry install --only=test` installs pytest without Django, so pytest aborts
with `ModuleNotFoundError: No module named 'django'`. Because the command pipes
into `tee`, the step exits 0 and the job goes green. Every PR since has merged
against a check that measured nothing. The most recent run before this PR
([32311142291](https://github.com/basedosdados/backend/actions/runs/32311142291))
shows the traceback under a passing job.

This PR fixes CI, repairs the tests that were rotting behind it, and adds
coverage for the code where a wrong answer is silent rather than loud.

**Suite: 4 → 448 passing. Coverage: 44% → 73%.**

### Description

**CI (`ci-python.yaml`)**

- `poetry install --only main,test` — Django and the project's apps are needed
  by the suite; `dev` is excluded to keep the job lean
- a `postgres:14` service with the `DB_*` env the settings expect
- `shell: bash` for pipefail, so a pytest failure is no longer swallowed by `tee`
- `if: always()` on the coverage comment, so failures still report

**Repairing the existing suite**

With CI fixed, 27 of the 31 existing tests failed or errored against code that
had moved on beneath them:

| What broke | When |
|---|---|
| `Dataset.organization` became the `organizations` m2m; the conftest fixture still passed the old kwarg | Feb 2025 — cascaded to 24 tests |
| `Table.raw_data_url` removed from the model, not the fixtures | — |
| `full_coverage` / `Dataset.coverage` replaced by `full_temporal_coverage` / `temporal_coverage` | — |
| `backend.apps.payment` renamed `account_payment`; patch targets pointed at a dead module | May 2024 |
| GraphQL endpoint is `/api/v1/graphql`, tests used `/api/graphql/` | — |
| `CreateStripeSubscription` in `tests.gql` queried a field the mutation no longer exposes, invalidating the whole document and with it the login mutation every payment test depends on | — |
| the account fixture used `objects.create`, storing the password unhashed so login could never succeed | — |
| activation-email assertions predate the `is_prd()` guard | Jun 2024 |

Assertions were rewritten against the current model API, not deleted. Where a
data shape changed (`full_coverage` → `full_temporal_coverage`), the new
expectations were derived by observing actual behaviour and checking it still
matched the original tests' intent.

**New tests**

Aimed at authorization, entitlement routing, and the aggregates behind the
public catalogue counts:

- **Dataset aggregates** (31) — ~15 rollup properties each re-spell the same
  "exclude `under_review`/`excluded` status and the dictionary tables" rule
  longhand, with nothing checking the copies agree
- **Model validation** (40) — Coverage, Update, Poll and QualityCheck each
  reimplement the same "exactly one foreign key" rule; plus `DateTimeRange`,
  which assembles datetimes out of seven nullable columns
- **Account HTTP views** (40) — activation, password reset, Google OAuth,
  including the `state` check against CSRF and the redirect-origin allowlist
  (that redirect carries a JWT, so an origin leaking onto the list is a token
  disclosure)
- **`account_auth` gateway** (32) — `/auth/` decides whether a reverse proxy
  lets a request through, so a wrongly-returned 200 is an authorization bypass;
  all six refusal paths covered
- **GraphQL decorators** (24) — `owner_required` and `subscription_member` are
  the authorization boundary for the API
- **Prefect flow-failure webhook** (42) — including the `reactivated_at` guard
  that stops a fixed flow being re-disabled by its own past failures
- **Stripe entitlements** (39) — chatbot-vs-BD-Pro detection, trial
  eligibility, and the admin guard that stops a webhook revoking a staff
  member's chatbot access
- **Table/Column relations** (25), **api/v1 REST endpoints** (20), **Account
  subscription state** (19), **environment allowlist** (5)

| Module | Before | After |
|---|---|---|
| `custom/environment.py` | 56% | 100% |
| `account_auth/views.py` | 18% | 96% |
| `account/views.py` | 40% | 93% |
| `account/models.py` | 78% | 91% |
| `custom/graphql_jwt.py` | 56% | 85% |
| `api/v1/models.py` | 68% | 85% |
| `admin_data_tools/views.py` | 25% | 72% |

**`backend/settings/test.py`**

New test settings module, wired via `pytest.ini`. Points haystack at the
in-memory backend and drops the search signal processor — without it every
`save()` in the suite tries to reach Elasticsearch and fails. Also supplies a
JWT algorithm and an in-memory email backend. Runtime drops from 37s to 27s.

### Bugs found by writing the tests

**Fixed (each with a test that fails without the fix):**

1. `CloudTable.clean` guarded the dataset-id check with `gcp_project_id`
   instead of `gcp_dataset_id`, so a malformed dataset id passed validation
   whenever the project id was blank.
2. `Token.save()` was declared `def save(self)` — no `*args, **kwargs` — so
   `Token.objects.create()` raised `TypeError` on `force_insert`. No Token
   could be created through the normal Django API.

**Documented in tests, not changed** — each alters runtime behaviour beyond
what a testing PR should decide alone:

3. **`Token.save()` regenerates the token on every save.** Editing a Token in
   the admin — setting an expiry, toggling `is_active` — silently invalidates
   the value the client is already using. Revoking becomes rotating. This is
   the one most worth a second opinion.
4. `DatasetRedirectView` indexes `URL_MAPPING` directly, so any host outside
   the four it knows about is a `KeyError` and a 500, not a redirect.
5. Area similarity compares names by prefix, so an Area saved with a blank name
   scores as similar to every area and inflates the related-tables ranking.

**Worth checking separately:** `GRAPHQL_JWT["JWT_ALGORITHM"]` reads
`DJANGO_JWT_ALGORITHM` from the environment and falls back to `None`, which
makes django-graphql-jwt sign with `alg="none"`. Worth confirming every
deployment sets it.

### Checklist

- [x] I have reviewed the code changes.
- [x] I have tested the changes locally.
- [ ] I have updated the documentation if needed.
- [x] I have added/modified tests to ensure the changes are valid.

### Testing and evidence

Run locally against Python 3.11 at the `poetry.lock` versions, from an empty
database:

```
448 passed in 51.57s
TOTAL    9608   2610    73%
```

`ruff check` passes; all pre-commit hooks pass.

The CI change itself was validated by installing a real Poetry and confirming
`poetry install --only main,test` resolves (main + test, no dev), and that the
`pytest` console script imports `backend` without the project root on
`sys.path`.

### Next steps

Per the repo's Git Flow this same branch should also be PR'd into `dev` and
`staging` — happy to open those on request.

The largest remaining gaps are `account_payment/graphql.py` (46%) and
`webhooks.py` (30%): the Stripe mutation and handler bodies, which need real
`djstripe` fixture scaffolding. Getting past ~80% overall means committing to
that; worth doing as a follow-up rather than growing this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
