### PR TITLE
feat(admin_data_tools): add search by flow_name to Disabled Flow Schedules

### DIFF
--- a/backend/apps/admin_data_tools/admin.py
+++ b/backend/apps/admin_data_tools/admin.py
@@ -16,6 +16,7 @@ class DisabledFlowScheduleAdmin(admin.ModelAdmin):
         "reactivated_at",
     ]
     list_filter = ["is_schedule_active"]
+    search_fields = ["flow_name"]
     readonly_fields = ["flow_name", "deployment_id", "disabled_at", "reactivated_at"]
     fields = ["flow_name", "deployment_id", "disabled_at", "is_schedule_active", "reactivated_at"]
 


### PR DESCRIPTION
## Summary
- Adiciona `search_fields = ["flow_name"]` ao `DisabledFlowScheduleAdmin`, permitindo pesquisar os flows pelo nome na página "Disabled Flow Schedules" do admin.

## Test plan
- [x] Abrir a página do admin em `/admin/admin_data_tools/disabledflowschedule/`
- [x] Confirmar que a caixa de busca aparece e filtra corretamente por `flow_name`