### PR TITLE
feat: adiciona botão "Checar Metadados" no admin de Table - staging

### DIFF
--- a/backend/apps/admin_data_tools/urls.py
+++ b/backend/apps/admin_data_tools/urls.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from django.urls import path
 
-from .views import FlowFailedWebhookView, SyncDeploymentsView
+from .views import CheckMetadadosView, FlowFailedWebhookView, SyncDeploymentsView
 
 urlpatterns = [
     path("admin-tools/sync-deployments/", SyncDeploymentsView.as_view(), name="sync-deployments"),
     path("admin-tools/flow-failed/", FlowFailedWebhookView.as_view(), name="flow-failed"),
+    path("admin-tools/check-metadados/", CheckMetadadosView.as_view(), name="check-metadados"),
 ]

--- a/backend/apps/admin_data_tools/views.py
+++ b/backend/apps/admin_data_tools/views.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from backend.apps.api.v1.models import Table
 from backend.custom.client import get_gbq_client
+from backend.custom.environment import is_prd
 
 from ._prefect3_client import Prefect3Client
 from .models import DisabledFlowSchedule
@@ -282,6 +283,12 @@ class CheckMetadadosView(View):
     Chamada de dentro do admin autenticado (não machine-to-machine como as
     demais views deste módulo), então mantém a proteção de CSRF padrão do
     Django em vez do bearer token usado acima.
+
+    Compara sempre contra o projeto do BigQuery correspondente ao ambiente do
+    próprio admin (``is_prd()``): em staging/dev contra ``basedosdados-dev``
+    — onde os flows escrevem antes de promover pra prod —, em prod contra
+    ``basedosdados``. Sem isso, staging acabaria comparando contra dados que
+    ainda nem foram promovidos.
     """
 
     def post(self, request):
@@ -297,7 +304,8 @@ class CheckMetadadosView(View):
         table_id = request.POST.get("table_id")
         selected_table = Table.objects.get(id=table_id)
 
-        if not selected_table.gbq_slug:
+        cloud_table = selected_table.cloud_tables.first()
+        if not cloud_table:
             return JsonResponse(
                 {
                     "status": "erro",
@@ -307,9 +315,12 @@ class CheckMetadadosView(View):
                 }
             )
 
+        gcp_project_id = "basedosdados" if is_prd() else "basedosdados-dev"
+        gbq_slug = f"{gcp_project_id}.{cloud_table.gcp_dataset_id}.{cloud_table.gcp_table_id}"
+
         try:
             bq_client = get_gbq_client()
-            bq_table = bq_client.get_table(selected_table.gbq_slug)
+            bq_table = bq_client.get_table(gbq_slug)
         except Exception as exc:
             return JsonResponse(
                 {"status": "erro", "mensagem": f"Falha ao consultar o BigQuery: {exc}"}

--- a/backend/apps/admin_data_tools/views.py
+++ b/backend/apps/admin_data_tools/views.py
@@ -9,6 +9,9 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from loguru import logger
 
+from backend.apps.api.v1.models import Table
+from backend.custom.client import get_gbq_client
+
 from ._prefect3_client import Prefect3Client
 from .models import DisabledFlowSchedule
 
@@ -264,3 +267,92 @@ class FlowFailedWebhookView(View):
             return JsonResponse({"status": "ok", "action": "disabled"})
 
         return JsonResponse({"status": "ok", "action": "no_action"})
+
+
+class CheckMetadadosView(View):
+    """Compara o schema real da tabela no BigQuery com as colunas cadastradas na API.
+
+    Acionada pelo botão "Checar Metadados" na página de admin de uma `Table`
+    (``backend/templates/admin/change_form.html``) via
+    ``POST /admin-tools/check-metadados/``. Mesma checagem do
+    ``.github/workflows/scripts/check_metadata.py`` (repo pipelines), mas lendo
+    ``bq_client.get_table(...).schema`` em vez de consultar `INFORMATION_SCHEMA`
+    — é metadado da tabela, não uma query faturada.
+
+    Chamada de dentro do admin autenticado (não machine-to-machine como as
+    demais views deste módulo), então mantém a proteção de CSRF padrão do
+    Django em vez do bearer token usado acima.
+    """
+
+    def post(self, request):
+        """Handle the check-metadados request.
+
+        Args:
+            request: Incoming Django HTTP request, com ``table_id`` no POST.
+
+        Returns:
+            ``JsonResponse`` com ``status`` ("sucesso" ou "erro") e ``mensagem``
+            listando as discrepâncias encontradas (ou confirmando consistência).
+        """
+        table_id = request.POST.get("table_id")
+        selected_table = Table.objects.get(id=table_id)
+
+        if not selected_table.gbq_slug:
+            return JsonResponse(
+                {
+                    "status": "erro",
+                    "mensagem": (
+                        "Tabela sem CloudTable vinculada — não é possível checar o BigQuery."
+                    ),
+                }
+            )
+
+        try:
+            bq_client = get_gbq_client()
+            bq_table = bq_client.get_table(selected_table.gbq_slug)
+        except Exception as exc:
+            return JsonResponse(
+                {"status": "erro", "mensagem": f"Falha ao consultar o BigQuery: {exc}"}
+            )
+
+        bq_columns = {field.name.lower(): field for field in bq_table.schema}
+        db_columns = {column.name.lower(): column for column in selected_table.columns.all()}
+
+        discrepancias: list[str] = []
+
+        for name, field in bq_columns.items():
+            column = db_columns.get(name)
+            if column is None:
+                discrepancias.append(
+                    f"Coluna `{field.name}`: existe no BigQuery, não existe na API"
+                )
+                continue
+
+            bq_type = (field.field_type or "").upper()
+            api_type = (column.bigquery_type.name if column.bigquery_type else "").upper()
+            if bq_type != api_type:
+                discrepancias.append(
+                    f"Coluna `{field.name}`: tipo diferente "
+                    f"(BigQuery=`{bq_type}`, API=`{api_type}`)"
+                )
+
+            bq_desc = field.description or ""
+            api_desc = column.description or ""
+            if bq_desc != api_desc:
+                discrepancias.append(
+                    f"Coluna `{field.name}`: descrição diferente "
+                    f"(BigQuery=`{bq_desc}`, API=`{api_desc}`)"
+                )
+
+        for name, column in db_columns.items():
+            if name not in bq_columns:
+                discrepancias.append(
+                    f"Coluna `{column.name}`: existe na API, não existe no BigQuery"
+                )
+
+        if discrepancias:
+            return JsonResponse({"status": "erro", "mensagem": "\n".join(discrepancias)})
+
+        return JsonResponse(
+            {"status": "sucesso", "mensagem": "Metadados consistentes com o BigQuery."}
+        )

--- a/backend/apps/core/static/core/js/ferramentas.js
+++ b/backend/apps/core/static/core/js/ferramentas.js
@@ -55,3 +55,28 @@ fetch('/upload_columns/', {
 esconderCarregamento(); // Esconde o carregamento independente do resultado
 });
 };
+
+function checarMetadados() {
+
+const formData = new FormData();
+formData.append('table_id', document.getElementById('table_id').value);
+mostrarCarregamento();
+
+fetch('/admin-tools/check-metadados/', {
+    method: 'POST',
+    body: formData,
+    headers: {
+        'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+    }
+})
+.then(response => response.json())
+.then(data => {
+    alert(data.mensagem);
+})
+.catch(error => {
+    alert('Erro ao checar metadados: ' + error);
+})
+.finally(() => {
+esconderCarregamento();
+});
+};

--- a/backend/templates/admin/change_form.html
+++ b/backend/templates/admin/change_form.html
@@ -7,6 +7,10 @@
     Importar Colunas
 </button>
 
+<button type="button" onclick="checarMetadados()" class="btn btn-block {{ jazzmin_ui.button_classes.secondary }} btn-sm">
+    Checar Metadados
+</button>
+
 {% endif %}
 {% endblock %}
 {% block content %}


### PR DESCRIPTION
Mesmo conteúdo do #1066 (base `main`), abrindo também contra `staging` pra poder testar o botão manualmente no admin de staging antes de promover pra prod.

## Contexto

Em `pipelines`, `.github/workflows/scripts/check_metadata.py` já compara o schema de uma tabela no BigQuery com as colunas cadastradas na API, mas só roda via GitHub Action/CLI. Este PR traz a mesma checagem para o admin do backend, no mesmo padrão do botão "Importar Colunas" já existente na página de uma `Table`.

## O que muda

- `CheckMetadadosView` (`backend/apps/admin_data_tools/views.py`): recebe `table_id`, busca o schema real via `get_gbq_client()` (`backend/custom/client.py`) e compara com as `Column`s cadastradas — nome, tipo (`bigquery_type`) e descrição. Retorna a lista de discrepâncias ou confirmação de consistência.
- Nova rota `admin-tools/check-metadados/` em `backend/apps/admin_data_tools/urls.py`.
- `checarMetadados()` em `ferramentas.js`: faz o POST e mostra o resultado num `alert`.
- Botão "Checar Metadados" adicionado ao lado de "Importar Colunas" em `change_form.html`.
- A checagem compara sempre contra o projeto do BigQuery do próprio ambiente do admin (`is_prd()`): em staging/dev contra `basedosdados-dev` (onde os flows escrevem antes de promover pra prod), em prod contra `basedosdados`.

## Test plan

- [x] `ruff check`/`ruff format` limpos
- [x] `manage.py check` sem issues
- [ ] Testar o botão manualmente no admin de staging numa tabela com e sem discrepância conhecida, confirmando que compara contra `basedosdados-dev`
