### PR TITLE
feat: automatiza a sincronização de staging com main

### DIFF
--- a/.github/workflows/sync-staging.yaml
+++ b/.github/workflows/sync-staging.yaml
@@ -1,0 +1,83 @@
+---
+name: Sync staging with main
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+concurrency:
+  group: sync-staging
+  cancel-in-progress: false
+jobs:
+  sync:
+    name: Sync staging with main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout staging
+        uses: actions/checkout@v4
+        with:
+          ref: staging
+          fetch-depth: 0
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Check for commits in main not yet in staging
+        id: diff
+        run: |
+          git fetch origin main
+          if [ -z "$(git log staging..origin/main --oneline)" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Merge main into the sync branch
+        if: steps.diff.outputs.has_changes == 'true'
+        run: |
+          git checkout -B chore/main_to_staging staging
+          git merge origin/main -X ours -m "chore: sync staging and main"
+          git push --force -u origin chore/main_to_staging
+      - name: List PRs brought in from main
+        if: steps.diff.outputs.has_changes == 'true'
+        id: prs
+        run: |
+          PRS=$(git log staging..origin/main --format=%s | python3 -c "
+          import re, sys
+          seen = []
+          for line in sys.stdin:
+              for m in re.findall(r'#(\d+)', line):
+                  if m not in seen:
+                      seen.append(m)
+          print(', '.join(f'#{n}' for n in seen))
+          ")
+          echo "prs=$PRS" >> "$GITHUB_OUTPUT"
+      - name: Open (or reuse) the PR to staging
+        if: steps.diff.outputs.has_changes == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PRS="${{ steps.prs.outputs.prs }}"
+          if [ -n "$PRS" ]; then
+            TITLE="chore: sync staging and main - (PRs: $PRS)"
+          else
+            TITLE="chore: sync staging and main"
+          fi
+          BODY=$(printf 'Sincronização automática de `main` em `staging` (merge com `-X ours`, sem conflito real).\n\nPRs trazidos de `main`: %s' "${PRS:-nenhum commit referenciando PR}")
+          EXISTING_PR=$(gh pr list --head chore/main_to_staging --base staging --state open --json number -q '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" --title "$TITLE" --body "$BODY"
+            echo "number=$EXISTING_PR" >> "$GITHUB_OUTPUT"
+          else
+            gh pr create --base staging --head chore/main_to_staging --title "$TITLE" --body "$BODY"
+            NEW_PR=$(gh pr list --head chore/main_to_staging --base staging --state open --json number -q '.[0].number')
+            echo "number=$NEW_PR" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Merge the sync PR automatically
+        if: steps.diff.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          gh pr merge "${{ steps.pr.outputs.number }}" --merge --delete-branch


### PR DESCRIPTION
# Nova funcionalidade: sincronização automática de staging com main

# Contexto

Hoje, sincronizar `staging` com `main` é um processo manual (documentado em `Acesso direto ao banco de prod.md`/vault): checar se há commits novos, criar a branch `chore/main_to_staging`, mesclar `main` com `-X ours`, abrir PR pra `staging` e depois apagar a branch. Alguém precisa lembrar de fazer isso — quando não é feito a tempo, um PR de feature aberto contra `staging` vem "poluído" com commits de `main` que não têm relação com a feature (só porque a branch foi cortada de `main`).

Esse PR automatiza esse processo via GitHub Action. Documentação completa em #1072.

# O que a action faz

```text
push em main
        │
        ▼
Há commits em main que staging ainda não tem?
        │
   não ─┴─ sim
   │        │
 (para)     ▼
      checkout -B chore/main_to_staging staging
      git merge origin/main -X ours   (sem conflito real, mesmo processo manual)
      git push --force
        │
        ▼
Já existe um PR aberto chore/main_to_staging → staging?
        │
    sim ─┴─ não
    │         │
 gh pr edit   gh pr create
    │         │
    └────┬────┘
         ▼
  gh pr merge --merge --delete-branch
```

- Dispara em todo `push` em `main` (mais `workflow_dispatch` pra rodar manualmente se precisar).
- Só age se houver commits novos — não cria PR vazio.
- Reaproveita a branch/PR `chore/main_to_staging` em vez de acumular uma nova a cada push.
- Título do PR segue o padrão já usado nos syncs manuais: `chore: sync staging and main - (PRs: #X, #Y)`, extraindo os `#NNNN` das mensagens de commit.
- Mescla o PR automaticamente — não fica esperando alguém clicar em "Merge".
- `concurrency` serializa as execuções, pra não disputar o `push --force` se `main` receber vários pushes em sequência rápida.

# Pré-requisito

Isso só funciona se "Allow GitHub Actions to create and approve pull requests" estiver habilitado em Settings → Actions → General do repositório.

# Observação

O PR de sync é aberto e mesclado usando o `GITHUB_TOKEN` padrão, não um PAT — então workflows que disparam em `pull_request` (como o lint de título do `ci-pr.yaml`) não rodam nesse PR específico (limitação conhecida do GitHub pra evitar loops). Não é um problema aqui: o objetivo é só garantir que `staging` tenha os commits de `main`, não revisar o conteúdo (o merge com `-X ours` nunca gera conflito real pra revisar).

# Acompanhamento

Registro e test plan em #1072.